### PR TITLE
Port look-ahead camera search and acoustic warning thread

### DIFF
--- a/lib/filtered_road_classes.dart
+++ b/lib/filtered_road_classes.dart
@@ -1,0 +1,22 @@
+/// Enumeration of road classes that are filtered from lookups.
+///
+/// The original Python implementation defined a long list of road
+/// classes named with letters (A, B, C …).  Only class `J` was used in
+/// practice and mapped to the numeric identifier `10000`.  The
+/// [FilteredRoadClass] enum mirrors this behaviour.  A convenience
+/// [hasValue] method is provided for quick membership checks similar to
+/// the `Enum.has_value` helper in Python.
+enum FilteredRoadClass {
+  J(10000);
+
+  const FilteredRoadClass(this.value);
+  final int value;
+
+  /// Return `true` when [value] matches one of the defined road classes.
+  static bool hasValue(int value) {
+    for (final cls in FilteredRoadClass.values) {
+      if (cls.value == value) return true;
+    }
+    return false;
+  }
+}

--- a/lib/gps_thread.dart
+++ b/lib/gps_thread.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+import 'rectangle_calculator.dart';
+
+/// Simplified port of the GPS handling thread from the Python code base.  The
+/// original application relied on OS threads and condition variables to push
+/// GPS samples into the calculation pipeline.  In Dart we model this as a
+/// [Stream] of [VectorData] objects.  Consumers may listen to [stream] or
+/// forward the events to [RectangleCalculatorThread.addVectorSample].
+class GpsThread {
+  final StreamController<VectorData> _controller =
+      StreamController<VectorData>.broadcast();
+  bool _running = false;
+
+  /// Stream of incoming [VectorData] samples.
+  Stream<VectorData> get stream => _controller.stream;
+
+  /// Start emitting samples.  If a [source] stream is provided its events are
+  /// forwarded to listeners.  Otherwise samples can be pushed manually via
+  /// [addSample].
+  void start({Stream<VectorData>? source}) {
+    _running = true;
+    source?.listen((event) {
+      if (_running) {
+        _controller.add(event);
+      }
+    });
+  }
+
+  /// Push a single [VectorData] sample into the GPS stream.
+  void addSample(VectorData vector) {
+    if (_running) {
+      _controller.add(vector);
+    }
+  }
+
+  /// Stop emitting samples and close the underlying stream controller.
+  Future<void> stop() async {
+    _running = false;
+    await _controller.close();
+  }
+}

--- a/lib/linked_list_generator.dart
+++ b/lib/linked_list_generator.dart
@@ -26,6 +26,11 @@ class DoubleLinkedListNodes {
   Node? head;
   Node? tail;
   Node? node;
+  dynamic _treeGenerator;
+
+  void setTreeGeneratorInstance(dynamic generator) {
+    _treeGenerator = generator;
+  }
 
   void appendNode(Node newNode) {
     if (head == null) {

--- a/lib/most_probable_way.dart
+++ b/lib/most_probable_way.dart
@@ -1,0 +1,155 @@
+
+/// Port of the ``MostProbableWay`` helper from the Python code base.  The
+/// class keeps track of recently observed road names and determines the most
+/// probable road based on repeated observations.  The implementation here is
+/// intentionally lightweight; only the behaviour required by the tests has
+/// been translated.
+class MostProbableWay {
+  String _mostProbableRoad = '<>';
+  String _mostProbableSpeed = '';
+  String _previousRoad = '<>';
+  String _previousSpeed = '';
+  dynamic _mostProbableTags;
+  dynamic _previousTags;
+  bool _firstLookup = true;
+  bool nextMprListComplete = false;
+  final List<String> _lastRoadnameList = [];
+  final List<MapEntry<int, String>> _nextPossibleMprList = [];
+  int maxRoadNames = 0;
+  int maxPossibleMprCandidates = 0;
+  int unstableCounter = 0;
+
+  /// Max number of unstable updates before we accept a change.
+  final int unstableLimit = 3;
+
+  void increaseUnstableCounter() => unstableCounter++;
+  int getUnstableCounter() => unstableCounter;
+  void resetUnstableCounter() => unstableCounter = 0;
+
+  void setMaximumNumberOfRoadNames(int maxnum) {
+    maxRoadNames = maxnum;
+  }
+
+  void setMaximumNumberOfNextPossibleMprs(int maxnum) {
+    maxPossibleMprCandidates = maxnum;
+  }
+
+  List<String> get lastRoadnameList => List.unmodifiable(_lastRoadnameList);
+  List<MapEntry<int, String>> get nextPossibleMprList =>
+      List.unmodifiable(_nextPossibleMprList);
+
+  /// Add a candidate pair of (road class, road name) to the next possible list.
+  /// Returns ``'MAX_REACHED'`` when the internal capacity has been hit.
+  String addAttributesToNextPossibleMprList(int currentFr, String roadname) {
+    if (_nextPossibleMprList.length >= maxPossibleMprCandidates) {
+      return 'MAX_REACHED';
+    }
+    _nextPossibleMprList.add(MapEntry(currentFr, roadname));
+    return 'MAX_NOT_REACHED';
+  }
+
+  void clearNextPossibleMprList() {
+    _nextPossibleMprList.clear();
+  }
+
+  /// Maintain a sliding window of the most recent road names.  Once the maximum
+  /// number of road names is reached the buffer is cleared before the new entry
+  /// is appended, mirroring the Python behaviour.
+  void addRoadnameToRoadnameList(String roadname) {
+    if (_lastRoadnameList.length == maxRoadNames) {
+      _lastRoadnameList.clear();
+    }
+    _lastRoadnameList.add(roadname);
+  }
+
+  /// Determine whether the candidates stored in [_nextPossibleMprList] point to
+  /// a new most probable road.  The algorithm checks for consistency of the
+  /// road class and name across the collected candidates and also handles the
+  /// special case where the names indicate a crossroad (e.g. "A/B").
+  bool isNextPossibleMprNewMpr({
+    required int? currentFr,
+    required int mostProbableRoadClass,
+    required bool ramp,
+    required bool nextMprListComplete,
+  }) {
+    if (currentFr == null) return false;
+
+    if (0 <= mostProbableRoadClass && mostProbableRoadClass <= 1) {
+      setMaximumNumberOfNextPossibleMprs(6);
+    } else {
+      setMaximumNumberOfNextPossibleMprs(4);
+    }
+
+    if ((currentFr >= 0 && currentFr <= 1) || ramp) {
+      if (mostProbableRoadClass > 1) {
+        // In the original implementation the rectangle thread might update
+        // road candidates.  For the simplified port we simply allow the new
+        // motorway class to take precedence.
+        return true;
+      }
+      return true;
+    }
+
+    final roadClassEntries = _nextPossibleMprList.map((e) => e.key).toList();
+    final roadNameEntries = _nextPossibleMprList.map((e) => e.value).toList();
+
+    String? crossroad0;
+    String? crossroad1;
+    bool crossroadMpr = true;
+    for (final roadName in roadNameEntries) {
+      final parts = roadName.split('/');
+      if (parts.length == 2) {
+        crossroad0 = parts[0];
+        crossroad1 = parts[1];
+        break;
+      }
+    }
+
+    if (crossroad0 != null && crossroad1 != null) {
+      for (final name in roadNameEntries) {
+        if (!name.contains(crossroad0)) {
+          crossroadMpr = false;
+          break;
+        }
+      }
+      if (!crossroadMpr) {
+        crossroadMpr = true;
+        for (final name in roadNameEntries) {
+          if (!name.contains(crossroad1)) {
+            crossroadMpr = false;
+            break;
+          }
+        }
+      }
+    } else {
+      crossroadMpr = false;
+    }
+
+    final counts = <int, int>{};
+    for (final rc in roadClassEntries) {
+      counts[rc] = (counts[rc] ?? 0) + 1;
+    }
+
+    return nextMprListComplete &&
+        (_nextPossibleMprList.toSet().length == 1 ||
+            (counts[currentFr] ?? 0) == roadClassEntries.length ||
+            crossroadMpr);
+  }
+
+  bool isFirstLookup() => _firstLookup;
+  void setFirstLookup(bool lookup) => _firstLookup = lookup;
+
+  void setMostProbableRoad(String roadname) => _mostProbableRoad = roadname;
+  void setMostProbableSpeed(String speed) => _mostProbableSpeed = speed;
+  void setPreviousRoad(String roadname) => _previousRoad = roadname;
+  void setPreviousSpeed(String speed) => _previousSpeed = speed;
+  void setMostProbableTags(dynamic tags) => _mostProbableTags = tags;
+  void setPreviousTags(dynamic tags) => _previousTags = tags;
+
+  String getMostProbableRoad() => _mostProbableRoad;
+  String getMostProbableSpeed() => _mostProbableSpeed;
+  dynamic getMostProbableTags() => _mostProbableTags;
+  String getPreviousRoad() => _previousRoad;
+  String getPreviousSpeed() => _previousSpeed;
+  dynamic getPreviousTags() => _previousTags;
+}

--- a/lib/overspeed_checker.dart
+++ b/lib/overspeed_checker.dart
@@ -1,5 +1,6 @@
 class OverspeedChecker {
   int? _lastMaxSpeed;
+  int? lastDifference;
 
   void process(int? currentSpeed, Map<String, dynamic> overspeedEntry) {
     if (currentSpeed == null) {
@@ -39,8 +40,10 @@ class OverspeedChecker {
 
   void _processEntry(int value) {
     if (value == 10000) {
+      lastDifference = null;
       print("Resetting overspeed warning.");
     } else {
+      lastDifference = value;
       print("Overspeed by $value units.");
     }
   }

--- a/lib/point.dart
+++ b/lib/point.dart
@@ -1,0 +1,10 @@
+/// Simple 2D point used by geometry helpers.
+class Point {
+  double x;
+  double y;
+
+  Point([this.x = 0.0, this.y = 0.0]);
+
+  /// Returns a new [Point] representing the sum of this point and [other].
+  Point add(Point other) => Point(x + other.x, y + other.y);
+}

--- a/lib/rect.dart
+++ b/lib/rect.dart
@@ -1,0 +1,202 @@
+import 'dart:math' as math;
+
+import 'point.dart';
+
+/// Axis-aligned rectangle specified by its bounding coordinates.
+class Rect {
+  double left = 0.0;
+  double top = 0.0;
+  double right = 0.0;
+  double bottom = 0.0;
+
+  double height = 0.0;
+  double width = 0.0;
+
+  String ident = '';
+  String rectString = '';
+
+  /// Maximum distance (in tile units) used by [pointsCloseToBorder] when
+  /// checking if a point lies close to the rectangle boundary.
+  double maxCloseToBorderValue = 0.300;
+  double maxCloseToBorderValueLookAhead = 0.200;
+
+  Rect({Point? pt1, Point? pt2, List<double>? pointList}) {
+    setPoints(pt1, pt2, pointList);
+  }
+
+  /// Dispose of the rectangle by resetting all coordinates. Dart's garbage
+  /// collector will reclaim the object but the method mirrors the Python
+  /// ``delete_rect`` convenience.
+  void deleteRect() {
+    left = top = right = bottom = 0.0;
+    ident = '';
+    rectString = '';
+  }
+
+  /// Configure the rectangle using either two corner [Point]s or a list of
+  /// four coordinates.
+  void setPoints(Point? pt1, Point? pt2, List<double>? pointList) {
+    if (pointList != null) {
+      if (pointList.isNotEmpty && pointList.length < 4) {
+        left = top = right = bottom = 0.0;
+        return;
+      }
+      if (pointList.length == 4) {
+        left = pointList[0];
+        top = pointList[1];
+        right = pointList[2];
+        bottom = pointList[3];
+        return;
+      }
+    }
+
+    if (pt1 == null || pt2 == null) {
+      left = top = right = bottom = 0.0;
+      return;
+    }
+
+    left = math.min(pt1.x, pt2.x);
+    top = math.min(pt1.y, pt2.y);
+    right = math.max(pt1.x, pt2.x);
+    bottom = math.max(pt1.y, pt2.y);
+  }
+
+  void setRectangleIdent(String ident) => this.ident = ident;
+  String getRectangleIdent() => ident;
+
+  void setRectangleString(String rectString) => this.rectString = rectString;
+  String getRectangleString() => rectString;
+
+  double rectHeight() {
+    height = bottom - top;
+    return height;
+  }
+
+  double rectWidth() {
+    width = right - left;
+    return width;
+  }
+
+  Point topLeft() => Point(left, top);
+  Point bottomRight() => Point(right, bottom);
+  Point topRight() => Point(right, top);
+  Point bottomLeft() => Point(left, bottom);
+
+  /// Return a new rectangle expanded on all sides by [n] units.
+  Rect expandedBy(double n) {
+    return Rect(
+        pt1: Point(left - n, top - n), pt2: Point(right + n, bottom + n));
+  }
+
+  /// Combine this rectangle with [other] and return the smallest rectangle
+  /// that fully contains both.
+  Rect intersectRectWith(Rect other) {
+    final left = math.min(this.left, other.left);
+    final right = math.max(this.right, other.right);
+    final bottom = math.min(this.bottom, other.bottom);
+    final top = math.max(this.top, other.top);
+    return Rect(pointList: [left, top, right, bottom]);
+  }
+
+  /// Check whether the point `(x, y)` lies inside the rectangle using a
+  /// winding algorithm, mirroring the original Python implementation.
+  bool pointInRect(double? x, double? y) {
+    if (x == null || y == null) return false;
+    final rect = [topLeft(), topRight(), bottomLeft(), bottomRight()];
+    bool inside = false;
+    double pt1x = rect[0].x, pt1y = rect[0].y;
+    for (var i = 1; i <= rect.length; i++) {
+      final pt2x = rect[i % rect.length].x;
+      final pt2y = rect[i % rect.length].y;
+      if (y >= math.min(pt1y, pt2y)) {
+        if (y <= math.max(pt1y, pt2y)) {
+          if (x >= math.min(pt1x, pt2x)) {
+            if (x <= math.max(pt1x, pt2x)) {
+              if (pt1y != pt2y) {
+                inside = !inside;
+                if (inside) return inside;
+              }
+            }
+          }
+        }
+      }
+      pt1x = pt2x;
+      pt1y = pt2y;
+    }
+    return inside;
+  }
+
+  /// Returns `true` if the point `(x, y)` lies within [maxCloseToBorderValue]
+  /// (or [maxCloseToBorderValueLookAhead] when [lookAhead] is true) of any
+  /// rectangle edge. When [lookAheadMode] equals
+  /// ``"Construction area lookahead"`` the check always returns false.
+  bool pointsCloseToBorder(double x, double y,
+      {bool lookAhead = false, String lookAheadMode = 'Speed Camera lookahead'}) {
+    if (lookAheadMode == 'Construction area lookahead') {
+      return false;
+    }
+    final rect = [topLeft(), topRight(), bottomLeft(), bottomRight()];
+    final double maxVal =
+        lookAhead ? maxCloseToBorderValueLookAhead : maxCloseToBorderValue;
+    double pt1x = rect[0].x, pt1y = rect[0].y;
+    for (var i = 1; i <= rect.length; i++) {
+      final pt2x = rect[i % rect.length].x;
+      final pt2y = rect[i % rect.length].y;
+      if ((y - math.min(pt1y, pt2y)).abs() <= maxVal ||
+          (y - math.max(pt1y, pt2y)).abs() <= maxVal ||
+          (x - math.max(pt1x, pt2x)).abs() <= maxVal ||
+          (x - math.min(pt1x, pt2x)).abs() <= maxVal) {
+        return true;
+      }
+      pt1x = pt2x;
+      pt1y = pt2y;
+    }
+    return false;
+  }
+}
+
+/// Compute the intersection of two rectangles. If they do not overlap an empty
+/// rectangle (all zeros) is returned.
+Rect intersectRectangle(Rect a, Rect b) {
+  final left = math.max(a.left, b.left);
+  final top = math.max(a.top, b.top);
+  final right = math.min(a.right, b.right);
+  final bottom = math.min(a.bottom, b.bottom);
+  if (left >= right || top >= bottom) {
+    return Rect(pointList: [0, 0, 0, 0]);
+  }
+  return Rect(pointList: [left, top, right, bottom]);
+}
+
+/// Determine whether point ([x], [y]) lies within the intersection of [a] and
+/// [b].
+bool pointInIntersectedRect(Rect a, Rect b, double x, double y) {
+  final r = intersectRectangle(a, b);
+  return r.pointInRect(x, y);
+}
+
+/// Extrapolate a new rectangle by mirroring the movement from [previous] to
+/// [current].  This is a simplistic linear extrapolation used for look‑ahead
+/// predictions.
+Rect extrapolateRectangle(Rect previous, Rect current) {
+  final dx = current.left - previous.left;
+  final dy = current.top - previous.top;
+  return Rect(
+      pt1: Point(current.left + dx, current.top + dy),
+      pt2: Point(current.right + dx, current.bottom + dy));
+}
+
+/// Check whether the [point] lies inside any rectangle from [rects].
+bool checkAllRectangles(Point point, List<Rect> rects) {
+  return rects.any((r) => r.pointInRect(point.x, point.y));
+}
+
+/// Sort rectangles by area (ascending) and return the sorted list.
+List<Rect> sortRectangles(List<Rect> rects) {
+  rects.sort((a, b) {
+    final areaA = a.rectHeight() * a.rectWidth();
+    final areaB = b.rectHeight() * b.rectWidth();
+    return areaA.compareTo(areaB);
+  });
+  return rects;
+}

--- a/lib/road_resolver.dart
+++ b/lib/road_resolver.dart
@@ -1,0 +1,80 @@
+import 'dart:math' as math;
+
+/// Utilities that resolve road names and speed limits from OpenStreetMap style
+/// tag dictionaries.  These helpers offer a small subset of the original
+/// Python logic but provide compatible APIs so call sites remain unchanged.
+
+/// Determine potential dangers on the road by examining [tags].  In this port
+/// we simply return the subset of tags where the value equals ``true``.
+Map<String, bool> resolveDangersOnTheRoad(Map<String, dynamic> tags) {
+  final result = <String, bool>{};
+  tags.forEach((key, value) {
+    if (value == true) result[key] = true;
+  });
+  return result;
+}
+
+/// Parse a ``maxspeed`` value from [tags].  Supports values such as ``"50"`` or
+/// ``"50 km/h"``.  Returns ``null`` if no valid speed was found.
+int? resolveMaxSpeed(Map<String, dynamic> tags) {
+  final raw = tags['maxspeed'];
+  if (raw == null) return null;
+  final match = RegExp(r'([0-9]+)').firstMatch(raw.toString());
+  if (match == null) return null;
+  return int.tryParse(match.group(1)!);
+}
+
+/// Combine road name and max-speed resolution.  If [name] or [speed] are absent
+/// this function attempts to read them from [tags].
+({String? roadName, int? maxSpeed}) resolveRoadnameAndMaxSpeed(
+    Map<String, dynamic> tags,
+    {String? name,
+    int? speed}) {
+  final resolvedName = name ?? tags['name']?.toString();
+  final resolvedSpeed = speed ?? resolveMaxSpeed(tags);
+  return (roadName: resolvedName, maxSpeed: resolvedSpeed);
+}
+
+/// Apply a default max speed for a given road [className] when [maxSpeed] is
+/// not provided.  Defaults loosely mirror the mapping in the Python code.
+int processMaxSpeedForRoadClass(String className, int? maxSpeed) {
+  if (maxSpeed != null) return maxSpeed;
+  const defaults = {
+    'motorway': 130,
+    'trunk': 100,
+    'primary': 100,
+    'secondary': 80,
+    'tertiary': 60,
+    'residential': 50,
+    'living_street': 20,
+  };
+  return defaults[className] ?? 50;
+}
+
+/// Enrich each speed‑camera entry in [cameras] with additional attributes found
+/// in [attributes].  Each camera is expected to be a mutable map.
+void addAdditionalAttributesToSpeedcams(
+    List<Map<String, dynamic>> cameras, Map<String, dynamic> attributes) {
+  for (final cam in cameras) {
+    cam.addAll(attributes);
+  }
+}
+
+/// Combined tag helpers ----------------------------------------------------
+
+/// Check whether [tags] contain any keys present in [combined].
+bool checkCombinedTags(Map<String, dynamic> tags, Map<String, String> combined) {
+  return combined.keys.any(tags.containsKey);
+}
+
+/// Clear the combined tag cache.
+void clearCombinedTags(Map<String, String> combined) => combined.clear();
+
+/// Add all keys from [tags] into the [combined] cache.
+void addCombinedTags(Map<String, dynamic> tags, Map<String, String> combined) {
+  tags.forEach((key, value) => combined[key] = value.toString());
+}
+
+/// Determine whether a particular [key] exists in the [combined] cache.
+bool insideCombinedTags(String key, Map<String, String> combined) =>
+    combined.containsKey(key);

--- a/lib/thread_pool.dart
+++ b/lib/thread_pool.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+/// Minimal thread-pool style helper built on top of Dart's [Future] API. The
+/// original Python project used ``concurrent.futures`` to run blocking
+/// lookups in parallel.  In Dart we can achieve similar behaviour by spawning
+/// multiple futures and waiting for them to complete with [Future.wait].
+class ThreadPool {
+  final List<Future> _active = [];
+
+  /// Start a collection of tasks returned by [createTasks] and wait for all to
+  /// complete.  The results are returned in the same order as the tasks.  Each
+  /// invocation stores the futures in [_active] so callers may later await
+  /// [checkWorkerThreadStatus] to ensure the pool is idle.
+  Future<List<T>> startThreadPoolLookup<T>(
+      List<Future<T>> Function() createTasks) {
+    final tasks = createTasks();
+    _active.addAll(tasks);
+    return Future.wait(tasks);
+  }
+
+  /// Await completion of all active tasks.  This mirrors the status checks in
+  /// the original thread-pool implementation.
+  Future<void> checkWorkerThreadStatus() async {
+    if (_active.isEmpty) return;
+    await Future.wait(_active);
+    _active.clear();
+  }
+}
+
+/// Run a speed‑camera lookup asynchronously for the provided [lookup] callback.
+/// The callback receives a context object [arg] and must return a list of
+/// results.  The helper simply forwards the call but keeps the API similar to
+/// the Python implementation where it was dispatched on a background thread.
+Future<List<T>> speedCamLookupAhead<T, A>(A arg,
+    Future<List<T>> Function(A) lookup) async {
+  return lookup(arg);
+}
+
+/// Run a construction‑area lookup asynchronously.  Identical to
+/// [speedCamLookupAhead] but kept separate for clarity.
+Future<List<T>> constructionsLookupAhead<T, A>(A arg,
+    Future<List<T>> Function(A) lookup) async {
+  return lookup(arg);
+}

--- a/lib/voice_prompt_queue.dart
+++ b/lib/voice_prompt_queue.dart
@@ -1,1 +1,123 @@
+import 'dart:async';
+import 'dart:collection';
 
+/// Queue structure mirroring the Python `VoicePromptQueue`.  Individual
+/// categories are stored in their own [Queue] and consumers wait on a broadcast
+/// stream until any queue receives an item.
+class VoicePromptQueue {
+  final Queue<String> _gpsSignalQueue = Queue();
+  final Queue<String> _maxSpeedExceededQueue = Queue();
+  final Queue<String> _onlineQueue = Queue();
+  final Queue<String> _poiQueue = Queue();
+  final Queue<String> _cameraQueue = Queue();
+  final Queue<String> _infoQueue = Queue();
+  final Queue<String> _arQueue = Queue();
+
+  final StreamController<void> _notifier = StreamController<void>.broadcast();
+
+  void _notify() => _notifier.add(null);
+
+  /// Wait until any queue has an item and return the highest‑priority entry.
+  Future<String> consumeItems() async {
+    while (true) {
+      final item = _dequeue();
+      if (item != null) return item;
+      await _notifier.stream.first;
+    }
+  }
+
+  String? _dequeue() {
+    if (_cameraQueue.isNotEmpty && _gpsSignalQueue.isNotEmpty) {
+      _gpsSignalQueue.removeLast();
+      return _cameraQueue.removeLast();
+    }
+    if (_cameraQueue.isNotEmpty && _infoQueue.isNotEmpty) {
+      _infoQueue.removeLast();
+      return _cameraQueue.removeLast();
+    }
+    if (_cameraQueue.isNotEmpty && _onlineQueue.isNotEmpty) {
+      _onlineQueue.removeLast();
+      return _cameraQueue.removeLast();
+    }
+    if (_cameraQueue.isNotEmpty) return _cameraQueue.removeLast();
+    if (_arQueue.isNotEmpty) return _arQueue.removeLast();
+    if (_gpsSignalQueue.isNotEmpty &&
+        _maxSpeedExceededQueue.isNotEmpty &&
+        _onlineQueue.isNotEmpty) {
+      _gpsSignalQueue.removeLast();
+      _onlineQueue.removeLast();
+      return _maxSpeedExceededQueue.removeLast();
+    }
+    if (_gpsSignalQueue.isNotEmpty && _maxSpeedExceededQueue.isNotEmpty) {
+      _gpsSignalQueue.removeLast();
+      return _maxSpeedExceededQueue.removeLast();
+    }
+    if (_gpsSignalQueue.isNotEmpty && _onlineQueue.isNotEmpty) {
+      _onlineQueue.removeLast();
+      return _gpsSignalQueue.removeLast();
+    }
+    if (_maxSpeedExceededQueue.isNotEmpty && _onlineQueue.isNotEmpty) {
+      _onlineQueue.removeLast();
+      return _maxSpeedExceededQueue.removeLast();
+    }
+    if (_maxSpeedExceededQueue.isNotEmpty) {
+      return _maxSpeedExceededQueue.removeLast();
+    }
+    if (_gpsSignalQueue.isNotEmpty) {
+      return _gpsSignalQueue.removeLast();
+    }
+    if (_onlineQueue.isNotEmpty) {
+      return _onlineQueue.removeLast();
+    }
+    if (_poiQueue.isNotEmpty) {
+      return _poiQueue.removeLast();
+    }
+    if (_infoQueue.isNotEmpty) {
+      return _infoQueue.removeLast();
+    }
+    return null;
+  }
+
+  void produceGpsSignal(String item) {
+    _gpsSignalQueue.add(item);
+    _notify();
+  }
+
+  void produceInfo(String item) {
+    _infoQueue.add(item);
+    _notify();
+  }
+
+  void produceMaxSpeedExceeded(String item) {
+    _maxSpeedExceededQueue.add(item);
+    _notify();
+  }
+
+  void produceOnlineStatus(String item) {
+    _onlineQueue.add(item);
+    _notify();
+  }
+
+  void producePoiStatus(String item) {
+    _poiQueue.add(item);
+    _notify();
+  }
+
+  void produceArStatus(String item) {
+    _arQueue.add(item);
+    _notify();
+  }
+
+  void produceCameraStatus(String item) {
+    _cameraQueue.add(item);
+    _notify();
+  }
+
+  void clearGpsSignalQueue() => _gpsSignalQueue.clear();
+  void clearMaxSpeedExceededQueue() => _maxSpeedExceededQueue.clear();
+  void clearOnlineQueue() => _onlineQueue.clear();
+  void clearPoiQueue() => _poiQueue.clear();
+  void clearCameraQueue() => _cameraQueue.clear();
+  void clearInfoQueue() => _infoQueue.clear();
+  void clearArQueue() => _arQueue.clear();
+}

--- a/lib/voice_prompt_thread.dart
+++ b/lib/voice_prompt_thread.dart
@@ -1,54 +1,164 @@
 import 'package:flutter_tts/flutter_tts.dart';
 
+import 'voice_prompt_queue.dart';
+
+const String _basePath = 'python/sounds';
+
+/// Port of the Python `VoicePromptThread` used for acoustic warnings.
 class VoicePromptThread {
-  final FlutterTts _flutterTts = FlutterTts();
-  final dynamic voicePromptQueue;
+  final dynamic flutterTts;
+  final VoicePromptQueue voicePromptQueue;
   final dynamic dialogflowClient;
-  final bool aiVoicePrompts;
+  bool aiVoicePrompts;
+  final bool Function()? isResumed;
+  final bool Function()? runInBackground;
+  final Future<void> Function()? waitForMainEvent;
+
   bool _lock = false;
+  bool _running = true;
 
   VoicePromptThread({
     required this.voicePromptQueue,
     required this.dialogflowClient,
-    this.aiVoicePrompts = false,
-  }) {
+    dynamic tts,
+    this.aiVoicePrompts = true,
+    this.isResumed,
+    this.runInBackground,
+    this.waitForMainEvent,
+  }) : flutterTts = tts ?? FlutterTts() {
     _initializeTts();
   }
 
   Future<void> _initializeTts() async {
-    // Set the default voice to a female voice if available
-    List<dynamic> voices = await _flutterTts.getVoices;
-    for (var voice in voices) {
-      if (voice.toString().toLowerCase().contains("female")) {
-        await _flutterTts.setVoice(voice);
-        break;
+    try {
+      final voices = await flutterTts.getVoices;
+      for (final voice in voices) {
+        if (voice.toString().toLowerCase().contains('female')) {
+          await flutterTts.setVoice(voice);
+          break;
+        }
       }
+      await flutterTts.setSpeechRate(0.6);
+    } catch (_) {
+      // Ignore platform exceptions in headless environments.
     }
-
-    // Set the speaking rate
-    await _flutterTts.setSpeechRate(0.6); // Adjust as needed
   }
 
-  Future<void> synthesizeSpeech(String text) async {
-    await _flutterTts.speak(text);
+  /// Configure thread options like AI voice prompts.
+  void setConfigs({bool aiVoicePrompts = true}) {
+    this.aiVoicePrompts = aiVoicePrompts;
   }
 
-  Future<void> process() async {
-    var voiceEntry = voicePromptQueue.consumeItems();
+  /// Start consuming items from [voicePromptQueue] until [stop] is called.
+  Future<void> run() async {
+    while (_running) {
+      if (runInBackground?.call() ?? false) {
+        await (waitForMainEvent?.call() ?? Future.value());
+      }
+      if (!(isResumed?.call() ?? true)) {
+        voicePromptQueue.clearGpsSignalQueue();
+        voicePromptQueue.clearMaxSpeedExceededQueue();
+        voicePromptQueue.clearOnlineQueue();
+        voicePromptQueue.clearArQueue();
+        continue;
+      }
 
+      final voiceEntry = await voicePromptQueue.consumeItems();
+      if (!_running) break;
+      await process(voiceEntry);
+    }
+    voicePromptQueue.clearGpsSignalQueue();
+    voicePromptQueue.clearMaxSpeedExceededQueue();
+    voicePromptQueue.clearOnlineQueue();
+    voicePromptQueue.clearArQueue();
+  }
+
+  void stop() {
+    _running = false;
+  }
+
+  Future<void> process(String voiceEntry) async {
     while (_lock) {
-      await Future.delayed(Duration(milliseconds: 100));
+      await Future.delayed(const Duration(milliseconds: 50));
     }
 
     if (aiVoicePrompts) {
-      // Use Dialogflow to generate a response
-      var response = await dialogflowClient.detectIntent(voiceEntry);
-      print("Dialogflow response: $response");
-
-      // Convert Dialogflow response text to speech
+      final response = await dialogflowClient.detectIntent(voiceEntry);
       _lock = true;
       await synthesizeSpeech(response);
       _lock = false;
+    } else {
+      final sound = mapVoiceEntryToSound(voiceEntry);
+      if (sound != null) {
+        _lock = true;
+        await _playSound(sound);
+        _lock = false;
+      }
     }
+  }
+
+  Future<void> synthesizeSpeech(String text) async {
+    try {
+      await flutterTts.speak(text);
+    } catch (_) {}
+  }
+
+  Future<void> _playSound(String sound) async {
+    // Actual audio playback is platform specific.  For the purposes of the
+    // port we simply print the requested sound file.
+    print('Trigger sound $sound');
+  }
+
+  /// Map the incoming [voiceEntry] identifier to a sound file within
+  /// ``python/sounds``.  Returns `null` if no mapping exists.
+  String? mapVoiceEntryToSound(String voiceEntry) {
+    final map = <String, String>{
+      'EXIT_APPLICATION': 'app_exit.wav',
+      'ADDED_POLICE': 'police_added.wav',
+      'ADDING_POLICE_FAILED': 'police_failed.wav',
+      'STOP_APPLICATION': 'app_stopped.wav',
+      'OSM_DATA_ERROR': 'data_error.wav',
+      'INTERNET_CONN_FAILED': 'inet_failed.wav',
+      'HAZARD': 'hazard.wav',
+      'EMPTY_DATASET_FROM_SERVER': 'empty_data.wav',
+      'LOW_DOWNLOAD_DATA_RATE': 'low_download_rate.wav',
+      'GPS_OFF': 'gps_off.wav',
+      'GPS_LOW': 'gps_weak.wav',
+      'GPS_ON': 'gps_established.wav',
+      'SPEEDCAM_BACKUP': 'camera_backup.wav',
+      'SPEEDCAM_REINSERT': 'speed_cam_reinserted.wav',
+      'FIX_100': 'fix_100.wav',
+      'TRAFFIC_100': 'traffic_100.wav',
+      'MOBILE_100': 'mobile_100.wav',
+      'DISTANCE_100': 'distance_100.wav',
+      'FIX_300': 'fix_300.wav',
+      'TRAFFIC_300': 'traffic_300.wav',
+      'MOBILE_300': 'mobile_300.wav',
+      'DISTANCE_300': 'distance_300.wav',
+      'FIX_500': 'fix_500.wav',
+      'TRAFFIC_500': 'traffic_500.wav',
+      'MOBILE_500': 'mobile_500.wav',
+      'DISTANCE_500': 'distance_500.wav',
+      'FIX_1000': 'fix_1000.wav',
+      'TRAFFIC_1000': 'traffic_1000.wav',
+      'MOBILE_1000': 'mobile_1000.wav',
+      'DISTANCE_1000': 'distance_1000.wav',
+      'FIX_NOW': 'fix_now.wav',
+      'TRAFFIC_NOW': 'traffic_now.wav',
+      'MOBILE_NOW': 'mobile_now.wav',
+      'DISTANCE_NOW': 'distance_now.wav',
+      'CAMERA_AHEAD': 'camera_ahead.wav',
+      'WATER': 'water.wav',
+      'ACCESS_CONTROL': 'access_control.wav',
+      'POI_SUCCESS': 'poi_success.wav',
+      'POI_FAILED': 'poi_failed.wav',
+      'NO_ROUTE': 'no_route.wav',
+      'ROUTE_STOPPED': 'route_stopped.wav',
+      'POI_REACHED': 'poi_reached.wav',
+      'ANGLE_MISMATCH': 'angle_mismatch.wav',
+      'AR_HUMAN': 'human.wav',
+    };
+    final file = map[voiceEntry];
+    return file != null ? '$_basePath/$file' : null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   geolocator: ^11.1.0
   flutter_tts: ^4.0.2
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/cache_manager_test.dart
+++ b/test/cache_manager_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import '../lib/rectangle_calculator.dart';
+import '../lib/point.dart';
+
+void main() {
+  test('camera cache lookup and cleanup', () {
+    final calc = RectangleCalculatorThread();
+    calc.processAllSpeedCameras([
+      SpeedCameraEvent(latitude: 1, longitude: 1, fixed: true),
+    ]);
+    final res = calc.speedCamLookup(Point(1, 1));
+    expect(res.length, 1);
+    calc.cleanupMapContent();
+    expect(calc.speedCamLookup(Point(1, 1)).isEmpty, isTrue);
+  });
+}

--- a/test/filtered_road_classes_test.dart
+++ b/test/filtered_road_classes_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+import 'package:workspace/filtered_road_classes.dart';
+
+void main() {
+  test('hasValue recognises defined classes', () {
+    expect(FilteredRoadClass.hasValue(10000), isTrue);
+    expect(FilteredRoadClass.hasValue(9999), isFalse);
+  });
+}

--- a/test/geometry_extrapolation_test.dart
+++ b/test/geometry_extrapolation_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import '../lib/rect.dart';
+import '../lib/point.dart';
+
+void main() {
+  test('intersection and point checks', () {
+    final r1 = Rect(pt1: Point(0, 0), pt2: Point(2, 2));
+    final r2 = Rect(pt1: Point(1, 1), pt2: Point(3, 3));
+    final inter = intersectRectangle(r1, r2);
+    expect(inter.left, 1);
+    expect(pointInIntersectedRect(r1, r2, 1.5, 1.5), isTrue);
+  });
+
+  test('extrapolate and sort', () {
+    final r1 = Rect(pt1: Point(0, 0), pt2: Point(1, 1));
+    final r2 = Rect(pt1: Point(1, 1), pt2: Point(2, 2));
+    final ex = extrapolateRectangle(r1, r2);
+    expect(ex.left, 2);
+    final sorted = sortRectangles([r2, r1]);
+    expect(sorted.first.left, 0);
+  });
+}

--- a/test/geometry_test.dart
+++ b/test/geometry_test.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+
+import 'package:workspace/point.dart';
+import 'package:workspace/rect.dart';
+
+void main() {
+  group('Point and Rect', () {
+    test('point inside rectangle', () {
+      final rect = Rect(pt1: Point(0, 0), pt2: Point(10, 10));
+      expect(rect.pointInRect(5, 5), isTrue);
+      expect(rect.pointInRect(15, 5), isFalse);
+    });
+
+    test('points close to border', () {
+      final rect = Rect(pt1: Point(0, 0), pt2: Point(10, 10));
+      // point near left border
+      expect(rect.pointsCloseToBorder(0.05, 5), isTrue);
+      // far from border
+      expect(rect.pointsCloseToBorder(5, 5), isFalse);
+    });
+
+    test('expanded and intersect', () {
+      final r1 = Rect(pt1: Point(0, 0), pt2: Point(5, 5));
+      final r2 = r1.expandedBy(2);
+      expect(r2.left, equals(-2));
+      expect(r2.right, equals(7));
+      final r3 = Rect(pt1: Point(3, 3), pt2: Point(6, 6));
+      final r4 = r1.intersectRectWith(r3);
+      expect(r4.left, equals(0));
+      expect(r4.right, equals(6));
+      expect(r4.bottom, equals(5));
+    });
+  });
+}

--- a/test/gps_thread_test.dart
+++ b/test/gps_thread_test.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:workspace/gps_thread.dart';
+import 'package:workspace/rectangle_calculator.dart';
+
+void main() {
+  test('gps thread feeds rectangle calculator', () async {
+    final gps = GpsThread();
+    final calc = RectangleCalculatorThread();
+    final completer = Completer<GeoRect>();
+    calc.rectangles.listen((rect) {
+      if (!completer.isCompleted) {
+        completer.complete(rect);
+      }
+    });
+
+    calc.bindVectorStream(gps.stream);
+    gps.start();
+    gps.addSample(VectorData(
+        longitude: 1.0,
+        latitude: 1.0,
+        speed: 50,
+        bearing: 0,
+        direction: 'Main',
+        gpsStatus: 1,
+        accuracy: 5));
+
+    final rect = await completer.future
+        .timeout(const Duration(seconds: 1));
+    expect(rect, isNotNull);
+    expect(calc.lastRect!.pointInRect(1.0, 1.0), isTrue);
+
+    await gps.stop();
+    await calc.dispose();
+  });
+}

--- a/test/most_probable_way_test.dart
+++ b/test/most_probable_way_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:workspace/most_probable_way.dart';
+
+void main() {
+  test('roadname list resets when max reached', () {
+    final mpw = MostProbableWay();
+    mpw.setMaximumNumberOfRoadNames(2);
+    mpw.addRoadnameToRoadnameList('A');
+    mpw.addRoadnameToRoadnameList('B');
+    mpw.addRoadnameToRoadnameList('C');
+    expect(mpw.lastRoadnameList, ['C']);
+  });
+
+  test('detects consistent next possible MPR', () {
+    final mpw = MostProbableWay();
+    mpw.setMaximumNumberOfNextPossibleMprs(3);
+    mpw.addAttributesToNextPossibleMprList(1, 'Main');
+    mpw.addAttributesToNextPossibleMprList(1, 'Main');
+    mpw.addAttributesToNextPossibleMprList(1, 'Main');
+    final result = mpw.isNextPossibleMprNewMpr(
+        currentFr: 1,
+        mostProbableRoadClass: 1,
+        ramp: false,
+        nextMprListComplete: true);
+    expect(result, isTrue);
+  });
+}

--- a/test/overspeed_checker_test.dart
+++ b/test/overspeed_checker_test.dart
@@ -1,0 +1,12 @@
+import 'package:test/test.dart';
+import 'package:workspace/overspeed_checker.dart';
+
+void main() {
+  test('detects overspeed and reset', () {
+    final checker = OverspeedChecker();
+    checker.process(60, {'limit': 50});
+    expect(checker.lastDifference, 10);
+    checker.process(40, {});
+    expect(checker.lastDifference, isNull);
+  });
+}

--- a/test/rectangle_calculator_methods_test.dart
+++ b/test/rectangle_calculator_methods_test.dart
@@ -1,0 +1,269 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+import 'package:workspace/rectangle_calculator.dart';
+import 'package:workspace/linked_list_generator.dart';
+import 'package:workspace/rect.dart';
+
+void main() {
+  group('RectangleCalculatorThread helpers', () {
+    final calc = RectangleCalculatorThread();
+
+    test('calculateRectangleRadius', () {
+      final radius = calc.calculateRectangleRadius(3, 4);
+      expect(radius, closeTo(2.5, 1e-9));
+    });
+
+    test('calculatePoints2Angle mirrors python logic', () {
+      final values = calc.calculatePoints2Angle(0, 0, 10, 0);
+      expect(values[0], closeTo(10, 1e-9));
+      expect(values[1], closeTo(-10, 1e-9));
+      expect(values[2], closeTo(0, 1e-9));
+      expect(values[3], closeTo(0, 1e-9));
+    });
+
+    test('rotatePoints2Angle rotates around origin', () {
+      final values = calc.rotatePoints2Angle(1, -1, 0, 0, math.pi / 2);
+      expect(values[0], closeTo(0, 1e-9));
+      expect(values[2], closeTo(-1, 1e-9));
+      expect(values[1], closeTo(0, 1e-9));
+      expect(values[3], closeTo(1, 1e-9));
+    });
+
+    test('createGeoJsonTilePolygonAngle', () {
+      final poly =
+          calc.createGeoJsonTilePolygonAngle(1, 0, 0, 1, 1, 45.0);
+      expect(poly.length, equals(5));
+    });
+
+    test('road class lookups', () {
+      expect(calc.getRoadClassValue('primary'), equals(2));
+      expect(calc.getRoadClassSpeed('residential'), equals('30'));
+      expect(calc.getRoadClassTxt(2), 'primary');
+    });
+
+    test('processRoadName updates lastRoadName', () {
+      final updated = calc.processRoadName(
+          foundRoadName: true,
+          roadName: 'Main St',
+          foundCombinedTags: false,
+          roadClass: 'primary');
+      expect(updated, isTrue);
+      expect(calc.lastRoadName, equals('Main St'));
+    });
+
+    test('processMaxSpeed triggers overspeed checker', () {
+      calc.processMaxSpeed('50', true, currentSpeed: 70, roadName: 'Main St');
+      expect(calc.lastMaxSpeed, equals(50));
+      expect(calc.overspeedChecker.lastDifference, equals(20));
+    });
+
+    test('triggerCacheLookup sets road name and max speed', () async {
+      final linked = DoubleLinkedListNodes();
+      linked.appendNode(Node(
+        id: 1,
+        latitudeStart: 1.0,
+        longitudeStart: 1.0,
+        latitudeEnd: 1.0,
+        longitudeEnd: 1.0,
+      ));
+      final tree = {
+        1: {'name': 'Main St', 'maxspeed': '50', 'highway': 'residential'}
+      };
+      await calc.triggerCacheLookup(
+          latitude: 1.0,
+          longitude: 1.0,
+          linkedListGenerator: linked,
+          treeGenerator: tree);
+      expect(calc.lastRoadName, equals('Main St'));
+      expect(calc.lastMaxSpeed, equals(50));
+    });
+
+    test('updateNumberOfDistanceCameras increments counter', () {
+      expect(calc.numberDistanceCams, equals(0));
+      calc.updateNumberOfDistanceCameras({'role': 'device'});
+      calc.updateNumberOfDistanceCameras({'role': 'none'});
+      expect(calc.numberDistanceCams, equals(1));
+    });
+
+    test('direction and extrapolation helpers', () {
+      final rc = RectangleCalculatorThread();
+      rc.direction = 'N';
+      rc.matchingRect.setRectangleIdent('N');
+      rc.matchingRect.setRectangleString('EXTRAPOLATED');
+      rc.previousRect = Rect(pointList: [0, 0, 0, 0]);
+      rc.previousRect?.setRectangleString('EXTRAPOLATED');
+      expect(rc.hasSameDirection(), isTrue);
+      expect(rc.isExtrapolatedRectMatching(), isTrue);
+      expect(rc.isExtrapolatedRectPrevious(), isTrue);
+    });
+
+    test('startThreadPoolDataLookup executes', () async {
+      bool called = false;
+      Future<bool> dummy({
+        double latitude = 0,
+        double longitude = 0,
+        DoubleLinkedListNodes? linkedListGenerator,
+        Map<int, Map<String, dynamic>>? treeGenerator,
+        Rect? currentRect,
+      }) async {
+        called = true;
+        return true;
+      }
+
+      await RectangleCalculatorThread.startThreadPoolDataLookup(dummy,
+          lat: 1, lon: 2, waitTillCompleted: true);
+      expect(called, isTrue);
+    });
+
+    test('triggerOsmLookup returns elements', () async {
+      final mock = MockClient((req) async {
+        final body = jsonEncode({'elements': [
+          {'id': 1}
+        ]});
+        return http.Response(body, 200);
+      });
+      final result = await calc.triggerOsmLookup(
+          const GeoRect(minLat: 0, minLon: 0, maxLat: 1, maxLon: 1),
+          client: mock);
+      expect(result.success, isTrue);
+      expect(result.elements, isNotNull);
+      expect(result.elements!.length, equals(1));
+    });
+
+    test('uploadCameraToDrive writes json', () async {
+      final dir = await Directory.systemTemp.createTemp();
+      final path = '${dir.path}/cameras.json';
+      await File(path).writeAsString(jsonEncode({'cameras': []}));
+      final ok = await uploadCameraToDrive(
+          name: 'Test', latitude: 1.0, longitude: 2.0, camerasJsonPath: path);
+      expect(ok, isTrue);
+      final decoded =
+          jsonDecode(await File(path).readAsString()) as Map<String, dynamic>;
+      expect((decoded['cameras'] as List).length, equals(1));
+      final dup = await uploadCameraToDrive(
+          name: 'Test', latitude: 1.0, longitude: 2.0, camerasJsonPath: path);
+      expect(dup, isFalse);
+    });
+
+    test('speedCamLookupAhead emits cameras and counts distance cams', () async {
+      final calc = RectangleCalculatorThread();
+      final mock = MockClient((req) async {
+        final body = jsonEncode({
+          'elements': [
+            {
+              'lat': 1.0,
+              'lon': 2.0,
+              'tags': {'highway': 'speed_camera', 'name': 'A'}
+            },
+            {
+              'lat': 3.0,
+              'lon': 4.0,
+              'tags': {'role': 'device'}
+            }
+          ]
+        });
+        return http.Response(body, 200);
+      });
+      final events = <SpeedCameraEvent>[];
+      final sub = calc.cameras.listen(events.add);
+      await calc.speedCamLookupAhead(0, 0, 0, 0, client: mock);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(events.length, equals(1));
+      expect(calc.numberDistanceCams, equals(1));
+      await sub.cancel();
+    });
+
+    test('resolveDangersOnTheRoad updates info page', () {
+      final calc = RectangleCalculatorThread();
+      calc.resolveDangersOnTheRoad({'hazard': 'flood'});
+      expect(calc.kiviInfoPage, equals('FLOOD'));
+      calc.resolveDangersOnTheRoad({});
+      expect(calc.kiviInfoPage, isNull);
+    });
+
+    test('updateKiviMaxspeed and updateKiviRoadname behave as python', () {
+      final calc = RectangleCalculatorThread();
+      calc.updateKiviMaxspeed(50);
+      expect(calc.kiviMaxspeed, equals(50));
+      calc.updateKiviMaxspeed('cleanup');
+      expect(calc.kiviMaxspeed, isNull);
+      calc.updateKiviRoadname('Main/Cross');
+      expect(calc.kiviRoadname, equals('Cross/Main'));
+      calc.updateKiviRoadname('cleanup');
+      expect(calc.kiviRoadname, equals(''));
+    });
+
+    test('processOffline clears road name', () async {
+      final calc = RectangleCalculatorThread();
+      calc.lastMaxSpeed = '';
+      calc.updateKiviRoadname('Main', false);
+      await calc.processOffline();
+      expect(calc.kiviRoadname, equals(''));
+    });
+
+    test('processLookAheadInterrupts resolves road name', () async {
+      final calc = _TestCalc();
+      await calc.processLookAheadInterrupts();
+      expect(calc.lastRoadName, equals('Test Road'));
+      expect(calc.lastMaxSpeed, equals(''));
+    });
+
+    test('processLookaheadItems triggers lookups', () async {
+      final calc = _TestCalc();
+      final start = DateTime.now().subtract(const Duration(seconds: 120));
+      await calc.processLookaheadItems(start);
+      expect(calc.speedCalled, isTrue);
+      expect(calc.constructionCalled, isTrue);
+    });
+
+    test('processConstructionAreasLookupAheadResults stores areas', () {
+      final calc = RectangleCalculatorThread();
+      calc.processConstructionAreasLookupAheadResults([
+        {
+          'lat': 1.0,
+          'lon': 2.0,
+          'tags': {'construction': 'yes'}
+        }
+      ], 'construction_ahead', 0, 0);
+      expect(calc.constructionAreas.isNotEmpty, isTrue);
+    });
+  });
+}
+
+class _TestCalc extends RectangleCalculatorThread {
+  bool speedCalled = false;
+  bool constructionCalled = false;
+
+  @override
+  Future<String?> getRoadNameViaNominatim(double lat, double lon) async =>
+      'Test Road';
+
+  @override
+  Future<bool> internetAvailable() async => true;
+
+  @override
+  Future<void> speedCamLookupAhead(
+      double xtile, double ytile, double lon, double lat,
+      {http.Client? client}) async {
+    speedCalled = true;
+  }
+
+  @override
+  Future<void> constructionsLookupAhead(
+      double xtile, double ytile, double lon, double lat,
+      {http.Client? client}) async {
+    constructionCalled = true;
+  }
+
+  @override
+  Future<SpeedCameraEvent?> processPredictiveCameras(
+          double longitude, double latitude) async =>
+      null;
+}
+

--- a/test/road_resolver_test.dart
+++ b/test/road_resolver_test.dart
@@ -1,0 +1,20 @@
+import 'package:test/test.dart';
+import '../lib/road_resolver.dart';
+
+void main() {
+  test('resolve max speed and roadname', () {
+    final tags = {'maxspeed': '50', 'name': 'Main'};
+    final res = resolveRoadnameAndMaxSpeed(tags);
+    expect(res.roadName, 'Main');
+    expect(res.maxSpeed, 50);
+  });
+
+  test('combined tags cache', () {
+    final cache = <String, String>{};
+    addCombinedTags({'a': 1}, cache);
+    expect(checkCombinedTags({'a': 2}, cache), isTrue);
+    expect(insideCombinedTags('a', cache), isTrue);
+    clearCombinedTags(cache);
+    expect(cache.isEmpty, isTrue);
+  });
+}

--- a/test/thread_pool_test.dart
+++ b/test/thread_pool_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import '../lib/thread_pool.dart';
+
+void main() {
+  test('startThreadPoolLookup runs tasks concurrently', () async {
+    final pool = ThreadPool();
+    final sw = Stopwatch()..start();
+    final results = await pool.startThreadPoolLookup(() => [
+      Future.delayed(const Duration(milliseconds: 200), () => 1),
+      Future.delayed(const Duration(milliseconds: 200), () => 2),
+    ]);
+    sw.stop();
+    expect(results, [1, 2]);
+    expect(sw.elapsedMilliseconds < 400, isTrue);
+  });
+
+  test('speedCamLookupAhead proxies to callback', () async {
+    final list = await speedCamLookupAhead<int, int>(5,
+        (arg) async => [arg, arg + 1]);
+    expect(list, [5, 6]);
+  });
+}

--- a/test/voice_prompt_queue_test.dart
+++ b/test/voice_prompt_queue_test.dart
@@ -1,0 +1,21 @@
+import 'package:test/test.dart';
+
+import '../lib/voice_prompt_queue.dart';
+
+void main() {
+  test('camera prompts override gps signals', () async {
+    final queue = VoicePromptQueue();
+    queue.produceGpsSignal('GPS_LOW');
+    queue.produceCameraStatus('CAMERA_AHEAD');
+    final item = await queue.consumeItems();
+    expect(item, 'CAMERA_AHEAD');
+  });
+
+  test('maxspeed exceeded has priority over gps', () async {
+    final queue = VoicePromptQueue();
+    queue.produceGpsSignal('GPS_LOW');
+    queue.produceMaxSpeedExceeded('FIX_NOW');
+    final item = await queue.consumeItems();
+    expect(item, 'FIX_NOW');
+  });
+}

--- a/test/voice_prompt_thread_test.dart
+++ b/test/voice_prompt_thread_test.dart
@@ -1,0 +1,70 @@
+import 'package:test/test.dart';
+
+import '../lib/voice_prompt_queue.dart';
+import '../lib/voice_prompt_thread.dart';
+
+class FakeTts {
+  String? lastText;
+  Future<List<dynamic>> get getVoices async => [];
+  Future<void> setVoice(dynamic voice) async {}
+  Future<void> setSpeechRate(double rate) async {}
+  Future<void> speak(String text) async {
+    lastText = text;
+  }
+}
+
+class FakeDialogflow {
+  Future<String> detectIntent(String text) async => 'response:$text';
+}
+
+void main() {
+  test('ai voice prompts speak dialogflow response', () async {
+    final thread = VoicePromptThread(
+      voicePromptQueue: VoicePromptQueue(),
+      dialogflowClient: FakeDialogflow(),
+      tts: FakeTts(),
+      aiVoicePrompts: true,
+    );
+    await thread.process('hello');
+    expect((thread.flutterTts as FakeTts).lastText, 'response:hello');
+  });
+
+  test('non ai mapping returns sound path', () {
+    final thread = VoicePromptThread(
+      voicePromptQueue: VoicePromptQueue(),
+      dialogflowClient: FakeDialogflow(),
+      tts: FakeTts(),
+      aiVoicePrompts: false,
+    );
+    final sound = thread.mapVoiceEntryToSound('GPS_OFF');
+    expect(sound, contains('gps_off.wav'));
+  });
+
+  test('setConfigs toggles aiVoicePrompts', () {
+    final thread = VoicePromptThread(
+      voicePromptQueue: VoicePromptQueue(),
+      dialogflowClient: FakeDialogflow(),
+      tts: FakeTts(),
+    );
+    thread.setConfigs(aiVoicePrompts: false);
+    expect(thread.aiVoicePrompts, isFalse);
+  });
+
+  test('run clears queues when not resumed', () async {
+    final queue = VoicePromptQueue();
+    queue.produceGpsSignal('GPS_ON');
+    final tts = FakeTts();
+    final thread = VoicePromptThread(
+      voicePromptQueue: queue,
+      dialogflowClient: FakeDialogflow(),
+      tts: tts,
+      isResumed: () => false,
+    );
+
+    final future = thread.run();
+    await Future.delayed(const Duration(milliseconds: 100));
+    thread.stop();
+    await future;
+    expect(tts.lastText, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- add speed camera look-ahead using Overpass results and count distance devices
- expose hazard resolution and KIVI UI update helpers with cleanup behaviour
- wrap geometry helpers for rectangle intersection, extrapolation, and sorting to reach feature parity
- port acoustic warning thread with prioritized voice prompt queue and dialogflow TTS support
- provide configuration and resume-aware run loop for voice prompts

## Testing
- `dart format lib/rectangle_calculator.dart test/rectangle_calculator_methods_test.dart` *(command not found: dart)*
- `dart test` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*
- `sudo apt-get update` *(Invalid response from proxy: HTTP/1.1 403 Forbidden)*
- `sudo apt-get install -y dart` *(Unable to locate package dart)*
- `sudo apt-get install -y flutter` *(Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6890b1ce2b20832c89ba455ff69803dd