### PR TITLE
Port complete deviation checker logic

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+class Logger {
+  final String moduleName;
+  final StreamController<String>? logViewer;
+  bool alwaysLogToStdOut = true;
+
+  Logger(this.moduleName, {this.logViewer});
+
+  String _createLogLinePrefix(String level) {
+    final now = DateTime.now();
+    final logTime = now.toIso8601String();
+    final paddedModule = moduleName.padRight(40);
+    final paddedLevel = level.padRight(7);
+    return '$logTime - [SPEEDMASTER] - $paddedLevel - $paddedModule - ';
+  }
+
+  String createFormattedLogLine(String logString, {String level = 'INFO'}) {
+    return '${_createLogLinePrefix(level)}$logString';
+  }
+
+  void printLogLine(String logString, {String level = 'INFO'}) {
+    final line = createFormattedLogLine(logString, level: level);
+    if (logViewer != null) {
+      logViewer!.add(line);
+    }
+    if (logViewer == null || alwaysLogToStdOut) {
+      print(line);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- model DeviationCheckerThread as a stoppable run loop with interrupt signals and cleanup
- drive average bearing text via ValueNotifier to mirror Kivy Clock updates
- add structured Logger and route deviation checker logs through it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891e31867b0832c95d7203d52e76c2d