### PR TITLE
feat: port GpsData.py functionality to Dart

### DIFF
--- a/lib/gps_test_data_generator.dart
+++ b/lib/gps_test_data_generator.dart
@@ -1,23 +1,77 @@
+import 'dart:io';
 import 'dart:math';
 
-class GpsTestDataGenerator {
+import 'package:gpx/gpx.dart';
+
+/// Generates mock GPS events for testing.
+///
+/// The generator can either create a list of synthetic GPS events or read
+/// events from a provided GPX file. Instances of this class are iterable so the
+/// generated events can be consumed with standard iteration constructs.
+class GpsTestDataGenerator extends Iterable<Map<String, dynamic>> {
+  /// Collected GPS events.
   final List<Map<String, dynamic>> events = [];
+
   final Random _random = Random();
 
-  GpsTestDataGenerator({int maxNum = 50000}) {
-    _fillEvents(maxNum);
+  /// Index used when iterating with [next].
+  int _eventIndex = -1;
+
+  /// Flag kept for parity with the original Python implementation.
+  bool startup = true;
+
+  /// Creates a [GpsTestDataGenerator].
+  ///
+  /// If [gpxFile] is provided, events will be created from the GPX file.
+  /// Otherwise [maxNum] synthetic events are generated.
+  GpsTestDataGenerator({int maxNum = 50000, String? gpxFile}) {
+    if (gpxFile != null) {
+      _fillEventsFromGpx(gpxFile);
+    } else {
+      _fillEvents(maxNum);
+    }
   }
 
+  /// Populates [events] from entries of the GPX file at [gpxFile].
+  void _fillEventsFromGpx(String gpxFile) {
+    print(' Generating Test GPS Data from $gpxFile....');
+
+    final gpxString = File(gpxFile).readAsStringSync();
+    final gpx = GpxReader().fromString(gpxString);
+
+    for (final track in gpx.trks) {
+      for (final segment in track.trksegs) {
+        for (final point in segment.trkpts) {
+          print('Point at (${point.lat},${point.lon}) -> ${point.ele}');
+          events.add({
+            'data': {
+              'gps': {
+                'accuracy': _random.nextInt(24) + 2,
+                'latitude': point.lat,
+                'longitude': point.lon,
+                'speed': point.speed ?? (_random.nextInt(26) + 10),
+                'bearing': _random.nextInt(51) + 200,
+              },
+            },
+            'name': 'location',
+          });
+        }
+      }
+    }
+  }
+
+  /// Generates [maxNum] synthetic GPS events.
   void _fillEvents(int maxNum) {
-    print("Generating $maxNum Test GPS Data....");
+    print('Generating $maxNum Test GPS Data....');
 
-    // Start location (e.g., London)
-    double startLat = 51.509865;
+    double startLat = 51.509865; // Starting location (e.g., London)
     double startLong = -0.118092;
-    double i = 0.0000110;
-    double j = 0.0000110;
+    const double i = 0.0000110;
+    const double j = 0.0000110;
+    int counter = 0;
+    int bearing = 15;
 
-    for (int counter = 0; counter < maxNum; counter++) {
+    for (int _ = 0; _ < maxNum; _++) {
       events.add({
         'data': {
           'gps': {
@@ -25,19 +79,40 @@ class GpsTestDataGenerator {
             'latitude': startLat,
             'longitude': startLong,
             'speed': _random.nextInt(26) + 10,
-            'bearing': _random.nextInt(36) + 200,
-          }
+            'bearing': bearing,
+          },
         },
-        'name': 'location'
+        'name': 'location',
       });
 
-      // Increment latitude and longitude for simulation
-      startLat += i;
-      startLong += j;
+      counter += 1;
+      if (counter > 1000) {
+        startLat -= i;
+        startLong -= j;
+        bearing = 180;
+      } else {
+        startLat += i;
+        startLong += j;
+      }
     }
   }
 
-  List<Map<String, dynamic>> getEvents() {
-    return events;
+  /// Returns the next event in [events].
+  ///
+  /// Throws a [StateError] when no more events are available.
+  Map<String, dynamic> next() {
+    _eventIndex += 1;
+    if (_eventIndex < events.length) {
+      return events[_eventIndex];
+    }
+    throw StateError('No more events');
   }
+
+  /// Provides iteration over the generated events.
+  @override
+  Iterator<Map<String, dynamic>> get iterator => events.iterator;
+
+  @override
+  String toString() => events.toString();
 }
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.19.1"
   crypto:
     dependency: transitive
     description:
@@ -144,6 +144,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
+  gpx:
+    dependency: "direct main"
+    description:
+      name: gpx
+      sha256: "f5b12b86402c639079243600ee2b3afd85cd08d26117fc8885cf48efce471d8e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   lints:
     dependency: transitive
     description:
@@ -172,10 +180,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -184,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "9436fe11f82d7cc1642a8671e5aa4149ffa9ae9116e6cf6dd665fc0653e3825c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -192,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: "ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -285,6 +309,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.4-beta"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "3202a47961c1a0af6097c9f8c1b492d705248ba309e6f7a72410422c05046851"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.0"
 sdks:
   dart: ">=3.1.0 <4.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   geolocator: ^11.1.0
   flutter_tts: ^4.0.2
+  gpx: ^2.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- port Python `GpsData` features to Dart, including GPX parsing and synthetic GPS data generation
- expose iterable GPS event generator with `next` helper
- add `gpx` dependency

## Testing
- `dart format lib/gps_test_data_generator.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891e34eb814832ca57d73854aabc970