### PR TITLE
Port LocationManager from Python

### DIFF
--- a/lib/location_manager.dart
+++ b/lib/location_manager.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+
+import 'package:geolocator/geolocator.dart';
+
+import 'rectangle_calculator.dart';
+
+/// Port of the Python `LocationManager` which requested location updates on
+/// Android and forwarded them to a queue.  In Dart we expose a stream of
+/// [VectorData] instances constructed from [Position] updates provided by the
+/// `geolocator` package.  Consumers can listen to [stream] to receive the
+/// converted GPS samples.
+class LocationManager {
+  final StreamController<VectorData> _controller =
+      StreamController<VectorData>.broadcast();
+  StreamSubscription<Position>? _subscription;
+
+  /// Stream of [VectorData] samples derived from GPS updates.
+  Stream<VectorData> get stream => _controller.stream;
+
+  /// Start listening to location updates.
+  ///
+  /// When [positionStream] is supplied it will be used as the source of
+  /// [Position] events.  Otherwise a stream from [Geolocator.getPositionStream]
+  /// will be created.  The [minTime] and [minDistance] arguments mirror the
+  /// behaviour of the original Python implementation where the underlying
+  /// Android `LocationManager` was configured with a minimum update interval and
+  /// distance.
+  Future<void> start(
+      {Stream<Position>? positionStream,
+      int minTime = 1000,
+      double minDistance = 1}) async {
+    Stream<Position> stream;
+
+    if (positionStream != null) {
+      stream = positionStream;
+    } else {
+      // Request permissions when using the real geolocator stream.
+      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        throw Exception('Location services are disabled');
+      }
+
+      LocationPermission permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+        if (permission == LocationPermission.denied) {
+          throw Exception('Location permissions are denied');
+        }
+      }
+
+      if (permission == LocationPermission.deniedForever) {
+        throw Exception('Location permissions are permanently denied');
+      }
+
+      stream = Geolocator.getPositionStream(
+          locationSettings: LocationSettings(
+        accuracy: LocationAccuracy.best,
+        distanceFilter: minDistance.round(),
+        timeLimit: Duration(milliseconds: minTime),
+      ));
+    }
+
+    _subscription = stream.listen(_onPosition);
+  }
+
+  void _onPosition(Position position) {
+    final vector = VectorData(
+      longitude: position.longitude,
+      latitude: position.latitude,
+      speed: position.speed,
+      bearing: position.heading,
+      accuracy: position.accuracy,
+      direction: '',
+      gpsStatus: 1,
+    );
+    _controller.add(vector);
+  }
+
+  /// Stop listening to location updates and close the stream.
+  Future<void> stop() async {
+    await _subscription?.cancel();
+    await _controller.close();
+  }
+}
+

--- a/test/location_manager_test.dart
+++ b/test/location_manager_test.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:workspace/location_manager.dart';
+import 'package:workspace/rectangle_calculator.dart';
+
+void main() {
+  test('location manager forwards position as vector data', () async {
+    final controller = StreamController<Position>();
+    final manager = LocationManager();
+
+    manager.start(positionStream: controller.stream);
+
+    final future = manager.stream.first;
+
+    controller.add(Position(
+      longitude: 1.0,
+      latitude: 2.0,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
+      accuracy: 5.0,
+      altitude: 0.0,
+      heading: 4.0,
+      speed: 3.0,
+      speedAccuracy: 0.0,
+    ));
+
+    final VectorData data = await future;
+
+    expect(data.longitude, 1.0);
+    expect(data.latitude, 2.0);
+    expect(data.speed, 3.0);
+    expect(data.bearing, 4.0);
+    expect(data.accuracy, 5.0);
+
+    await manager.stop();
+    await controller.close();
+  });
+}
+


### PR DESCRIPTION
## Summary
- Port LocationManager to Dart using geolocator, streaming Position updates as VectorData
- Add unit test verifying Position events convert to VectorData correctly

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891eb6aa9c8832cbeeccb2cda817600