### PR TITLE
feat: port service account utilities

### DIFF
--- a/lib/service_account.dart
+++ b/lib/service_account.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:googleapis/drive/v3.dart' as drive;
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:path/path.dart' as p;
+
+import 'logger.dart';
+
+class ServiceAccount {
+  static final Logger logger = Logger('ServiceAccount');
+
+  static String basePath =
+      p.join(Directory.current.path, 'python', 'service_account');
+  static String serviceAccount =
+      p.join(basePath, 'osmwarner-01bcd4dc2dd3.json');
+  static String folderId = '1VlWuYw_lGeZzrVt5P-dvw8ZzZWSXpaQR';
+  static String fileName = p.join(basePath, 'cameras.json');
+  static List<String> scopes = [drive.DriveApi.driveScope];
+  static String fileId = '1T-Frq3_M-NaGMenIZpTHjrjGusBgoKgE';
+  static int requestLimit = 1;
+  static Duration timeLimit = const Duration(seconds: 2);
+
+  static Map<String, _RequestRecord> userRequests = {};
+
+  static Future<Map<String, dynamic>> loadServiceAccount() async {
+    final content = await File(serviceAccount).readAsString();
+    return jsonDecode(content) as Map<String, dynamic>;
+  }
+
+  static Future<Object> buildDriveFromCredentials() async {
+    try {
+      final jsonCredentials = await File(serviceAccount).readAsString();
+      final accountCredentials =
+          ServiceAccountCredentials.fromJson(json.decode(jsonCredentials));
+      final client = await clientViaServiceAccount(accountCredentials, scopes);
+      return drive.DriveApi(client);
+    } on FileSystemException catch (e) {
+      return e.toString();
+    }
+  }
+
+  static bool checkRateLimit(String user) {
+    final now = DateTime.now();
+    final record = userRequests[user];
+    if (record != null) {
+      if (now.difference(record.timestamp) <= timeLimit) {
+        if (record.count > requestLimit) {
+          return false;
+        } else {
+          userRequests[user] =
+              _RequestRecord(record.timestamp, record.count + 1);
+        }
+      } else {
+        userRequests[user] = _RequestRecord(now, 1);
+      }
+    } else {
+      userRequests[user] = _RequestRecord(now, 1);
+    }
+    return true;
+  }
+
+  static Future<(bool, String?)> addCameraToJson(
+      String name, double latitude, double longitude) async {
+    if (!checkRateLimit('master_user')) {
+      logger.printLogLine(
+          "Dismiss Camera upload: Rate limit exceeded for user: 'master_user'",
+          level: 'WARNING');
+      return (false, 'RATE_LIMIT_EXCEEDED');
+    }
+
+    final newCamera = {
+      'name': name,
+      'coordinates': [
+        {'latitude': latitude, 'longitude': longitude}
+      ]
+    };
+    logger.printLogLine('Adding new camera: $newCamera');
+
+    Map<String, dynamic> content;
+    try {
+      final jsonContent = await File(fileName).readAsString();
+      content = jsonDecode(jsonContent) as Map<String, dynamic>;
+    } on FileSystemException {
+      logger.printLogLine(
+        'addCameraToJson() failed: $fileName not found!',
+        level: 'ERROR',
+      );
+      return (false, 'CAM_FILE_NOT_FOUND');
+    }
+
+    final existingCameras = List<Map<String, dynamic>>.from(
+        content['cameras'] as List<dynamic>? ?? []);
+    for (final camera in existingCameras) {
+      final coords = camera['coordinates'][0] as Map<String, dynamic>;
+      if (coords['latitude'] == latitude && coords['longitude'] == longitude) {
+        logger.printLogLine(
+          'Dismiss Camera upload: Duplicate coordinates detected: '
+          '($latitude, $longitude)',
+          level: 'WARNING',
+        );
+        return (false, 'DUPLICATE_COORDINATES');
+      }
+    }
+
+    existingCameras.add(newCamera);
+    content['cameras'] = existingCameras;
+    final encoder = const JsonEncoder.withIndent('    ');
+    await File(fileName).writeAsString(encoder.convert(content));
+    return (true, null);
+  }
+
+  static Future<String> uploadFileToGoogleDrive(
+      String id, String folderId, Object driveOrError,
+      {String? uploadFileName}) async {
+    if (driveOrError is String) {
+      return driveOrError;
+    }
+    final driveApi = driveOrError as drive.DriveApi;
+    final fname = uploadFileName ?? fileName;
+    try {
+      final file = await driveApi.files.get(id, $fields: 'parents');
+      final currentParents = (file.parents ?? []).join(',');
+      final media =
+          drive.Media(File(fname).openRead(), await File(fname).length());
+      final updated = await driveApi.files.update(
+        drive.File(),
+        id,
+        addParents: folderId,
+        removeParents: currentParents,
+        uploadMedia: media,
+      );
+      final newId = updated.id;
+      logger.printLogLine(
+          'Camera upload success: File ID $newId has been moved to folder ID $folderId.');
+      return 'success';
+    } catch (e) {
+      return 'An error occurred: $e';
+    }
+  }
+
+  static Future<String> downloadFileFromGoogleDrive(
+      String id, Object driveOrError) async {
+    if (driveOrError is String) {
+      return driveOrError;
+    }
+    final driveApi = driveOrError as drive.DriveApi;
+
+    drive.File fileMeta;
+    String filePath;
+    try {
+      fileMeta = await driveApi.files.get(id, $fields: 'name');
+      filePath = p.join(basePath, fileMeta.name!);
+    } catch (e) {
+      return e.toString();
+    }
+
+    try {
+      final media = await driveApi.files.get(id,
+          downloadOptions: drive.DownloadOptions.fullMedia) as drive.Media;
+      final saveFile = File(filePath).openWrite();
+      await media.stream.pipe(saveFile);
+      await saveFile.close();
+    } catch (e) {
+      return e.toString();
+    }
+
+    return 'success';
+  }
+}
+
+class _RequestRecord {
+  final DateTime timestamp;
+  final int count;
+  _RequestRecord(this.timestamp, this.count);
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   uuid: ^4.5.1
   audioplayers: ^5.1.0
   http: ^1.1.0
+  googleapis: ^13.1.0
+  googleapis_auth: ^1.5.4
 
 dev_dependencies:
   flutter_test:

--- a/test/service_account_test.dart
+++ b/test/service_account_test.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../lib/service_account.dart';
+
+void main() {
+  group('ServiceAccount', () {
+    test('checkRateLimit enforces request limit', () {
+      ServiceAccount.userRequests.clear();
+      expect(ServiceAccount.checkRateLimit('user'), isTrue);
+      expect(ServiceAccount.checkRateLimit('user'), isFalse);
+    });
+
+    test('addCameraToJson adds and rejects duplicates', () async {
+      final originalFileName = ServiceAccount.fileName;
+      final tempDir = Directory.systemTemp.createTempSync();
+      final tempFile = File(p.join(tempDir.path, 'cameras.json'));
+      await tempFile.writeAsString(jsonEncode({'cameras': []}));
+      ServiceAccount.fileName = tempFile.path;
+      ServiceAccount.userRequests.clear();
+
+      var res = await ServiceAccount.addCameraToJson('test', 1.0, 2.0);
+      expect(res.$1, isTrue);
+
+      ServiceAccount.userRequests.clear();
+      res = await ServiceAccount.addCameraToJson('test', 1.0, 2.0);
+      expect(res.$1, isFalse);
+      expect(res.$2, 'DUPLICATE_COORDINATES');
+
+      final content =
+          jsonDecode(await tempFile.readAsString()) as Map<String, dynamic>;
+      expect((content['cameras'] as List).length, 1);
+
+      ServiceAccount.fileName = originalFileName;
+      tempDir.deleteSync(recursive: true);
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- port `ServiceAccount.py` to Dart with Google Drive helpers, rate limiting, and camera JSON handling
- add unit tests for rate limiting and duplicate camera protection
- include Google API dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/service_account.dart test/service_account_test.dart pubspec.yaml` *(fails: command not found)*
- `flutter test test/service_account_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ec149024832c915193e462ddb7ff