### PR TITLE
Add start/stop/exit action page and stats view

### DIFF
--- a/lib/ui/actions_page.dart
+++ b/lib/ui/actions_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../app_controller.dart';
+
+/// Simple page providing Start, Stop and Exit controls.
+///
+/// Mirrors the action layout from the legacy ``main.py`` where the buttons
+/// were stacked vertically.
+class ActionsPage extends StatelessWidget {
+  final AppController controller;
+  const ActionsPage({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Actions')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildButton('Start', controller.start),
+            const SizedBox(height: 16),
+            _buildButton('Stop', controller.stop),
+            const SizedBox(height: 16),
+            _buildButton('Exit', () async {
+              await controller.stop();
+              SystemNavigator.pop();
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildButton(String label, Future<void> Function() onPressed) {
+    return SizedBox(
+      height: 80,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(label, style: const TextStyle(fontSize: 32)),
+      ),
+    );
+  }
+}

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
 import '../app_controller.dart';
+import 'actions_page.dart';
 import 'ar_page.dart';
 import 'dashboard.dart';
 import 'info_page.dart';
 import 'map_page.dart';
+import 'stats_page.dart';
 
 /// Root widget with a bottom navigation bar that switches between the main
 /// screens of the application.  It also manages the [AppController]
@@ -24,8 +26,8 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
-    widget.controller.start();
     _pages = [
+      ActionsPage(controller: widget.controller),
       DashboardPage(
         calculator: widget.controller.calculator,
         arStatus: widget.controller.arStatusNotifier,
@@ -33,6 +35,7 @@ class _HomePageState extends State<HomePage> {
       MapPage(calculator: widget.controller.calculator),
       ArPage(controller: widget.controller),
       const InfoPage(),
+      StatsPage(calculator: widget.controller.calculator),
     ];
   }
 
@@ -51,10 +54,14 @@ class _HomePageState extends State<HomePage> {
         onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(
+              icon: Icon(Icons.power_settings_new), label: 'Actions'),
+          BottomNavigationBarItem(
               icon: Icon(Icons.dashboard), label: 'Dashboard'),
           BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
           BottomNavigationBarItem(icon: Icon(Icons.camera_alt), label: 'AR'),
-          BottomNavigationBarItem(icon: Icon(Icons.info_outline), label: 'Info'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.info_outline), label: 'Info'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Stats'),
         ],
       ),
     );

--- a/lib/ui/stats_page.dart
+++ b/lib/ui/stats_page.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../rectangle_calculator.dart';
+
+/// Displays counters for different camera and POI categories.
+///
+/// Mirrors the "MainView" statistics page from the legacy ``main.py``
+/// implementation where numbers of fixed, mobile, red light and predictive
+/// cameras were shown alongside POIs.  The counters update as the
+/// [RectangleCalculatorThread] emits [SpeedCameraEvent]s.
+class StatsPage extends StatefulWidget {
+  final RectangleCalculatorThread calculator;
+  const StatsPage({super.key, required this.calculator});
+
+  @override
+  State<StatsPage> createState() => _StatsPageState();
+}
+
+class _StatsPageState extends State<StatsPage> {
+  late final StreamSubscription<SpeedCameraEvent> _sub;
+  int _fixed = 0;
+  int _traffic = 0;
+  int _distance = 0; // Placeholder; no dedicated flag in current model
+  int _mobile = 0;
+  int _predictive = 0;
+  int _poi = 0; // Placeholder for future POI integration
+
+  @override
+  void initState() {
+    super.initState();
+    _sub = widget.calculator.cameras.listen((cam) {
+      setState(() {
+        if (cam.fixed) _fixed++;
+        if (cam.traffic) _traffic++;
+        if (cam.mobile) _mobile++;
+        if (cam.predictive) _predictive++;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Statistics')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          _buildRow('Fix Cameras', _fixed),
+          _buildRow('Red Light Cameras', _traffic),
+          _buildRow('Distance Cameras', _distance),
+          _buildRow('Mobile Cameras', _mobile),
+          _buildRow('Predictive Cameras', _predictive),
+          _buildRow('POIs', _poi),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(String label, int count) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(label, style: const TextStyle(fontSize: 24)),
+          Text('$count',
+              style:
+                  const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add Actions page exposing Start, Stop and Exit controls that manage backend threads
- Incorporate Stats page mirroring main.py's camera counters and wire it into navigation

## Testing
- `dart format lib/ui/home.dart lib/ui/actions_page.dart lib/ui/stats_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b339e7114832caf881916b992fa24