### PR TITLE
Prevent multiple stream listeners and remove geolocator timeout

### DIFF
--- a/lib/location_manager.dart
+++ b/lib/location_manager.dart
@@ -56,7 +56,11 @@ class LocationManager {
           locationSettings: LocationSettings(
         accuracy: LocationAccuracy.best,
         distanceFilter: minDistance.round(),
-        timeLimit: Duration(milliseconds: minTime),
+        // Using `timeLimit` here caused the stream to throw a
+        // `TimeoutException` if no location fix was available within the
+        // given duration.  The Python version intended this value to control
+        // the interval between updates, so we omit `timeLimit` to keep the
+        // stream alive until a fix is received.
       ));
     }
 

--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -266,6 +266,13 @@ class RectangleCalculatorThread {
   /// stop processing samples.
   bool _running = true;
 
+  /// Guard to ensure the processing loop is only attached once.  The
+  /// constructor calls [_start] and some external code may invoke [run]
+  /// for API parity.  Without this flag the stream would be listened to
+  /// multiple times which throws a ``Bad state: Stream has already been
+  /// listened to`` exception.
+  bool _started = false;
+
   /// The current zoom level used when converting between tiles and
   /// latitude/longitude.  You may expose this as a public field if your map
   /// layer needs to remain in sync with the calculator.
@@ -526,6 +533,8 @@ class RectangleCalculatorThread {
   /// incoming vector samples and processes them sequentially.  If
   /// [_running] becomes false the loop exits gracefully.
   void _start() {
+    if (_started) return;
+    _started = true;
     // ignore: unawaited_futures
     _vectorStreamController.stream.listen((vector) async {
       if (!_running) return;


### PR DESCRIPTION
## Summary
- Guard rectangle calculator start method to avoid multiple stream subscriptions
- Remove geolocator `timeLimit` to prevent startup timeout

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689b5381dea8832c8ce772a94f3b1c72