### PR TITLE
Prevent multiple stream listeners and remove geolocator timeout

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'gps_thread.dart';
 import 'location_manager.dart';
 import 'rectangle_calculator.dart';
+import 'package:geolocator/geolocator.dart';
 
 /// Central place that wires up background modules and manages their
 /// lifecycles.  The original Python project spawned numerous threads; in
@@ -30,9 +31,14 @@ class AppController {
   bool _running = false;
 
   /// Start background services if not already running.
-  Future<void> start() async {
+  ///
+  /// When [gpxFile] is provided the GPS module will replay coordinates from
+  /// that GPX track instead of querying the device's sensors. Tests may supply
+  /// a custom [positionStream] to avoid interacting with the real platform
+  /// services.
+  Future<void> start({String? gpxFile, Stream<Position>? positionStream}) async {
     if (_running) return;
-    await locationManager.start();
+    await locationManager.start(gpxFile: gpxFile, positionStream: positionStream);
     gps.start(source: locationManager.stream);
     calculator.run();
     _running = true;
@@ -43,7 +49,16 @@ class AppController {
     if (!_running) return;
     await gps.stop();
     await locationManager.stop();
-    await calculator.dispose();
+    calculator.stop();
     _running = false;
+  }
+
+  /// Fully dispose all resources.  Subsequent calls to [start] will require a
+  /// new [AppController] instance.
+  Future<void> dispose() async {
+    await stop();
+    await gps.dispose();
+    await locationManager.dispose();
+    await calculator.dispose();
   }
 }

--- a/lib/location_manager.dart
+++ b/lib/location_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:geolocator/geolocator.dart';
 
+import 'gps_test_data_generator.dart';
 import 'rectangle_calculator.dart';
 
 /// Port of the Python `LocationManager` which requested location updates on
@@ -13,6 +14,11 @@ class LocationManager {
   final StreamController<VectorData> _controller =
       StreamController<VectorData>.broadcast();
   StreamSubscription<Position>? _subscription;
+  Timer? _gpxTimer;
+  bool _running = false;
+
+  /// Whether the manager is currently publishing location updates.
+  bool get isRunning => _running;
 
   /// Stream of [VectorData] samples derived from GPS updates.
   Stream<VectorData> get stream => _controller.stream;
@@ -28,11 +34,38 @@ class LocationManager {
   Future<void> start(
       {Stream<Position>? positionStream,
       int minTime = 1000,
-      double minDistance = 1}) async {
-    Stream<Position> stream;
+      double minDistance = 1,
+      String? gpxFile}) async {
+    if (_running) return;
+    _running = true;
+    if (gpxFile != null) {
+      final generator = GpsTestDataGenerator(gpxFile: gpxFile);
+      final iterator = generator.iterator;
+      _gpxTimer = Timer.periodic(Duration(milliseconds: minTime), (timer) {
+        if (iterator.moveNext()) {
+          final gps = iterator.current['data']['gps'];
+          final vector = VectorData(
+            longitude: (gps['longitude'] as num).toDouble(),
+            latitude: (gps['latitude'] as num).toDouble(),
+            // speed in GPX/test data is m/s -> convert to km/h
+            speed: (gps['speed'] as num).toDouble() * 3.6,
+            bearing: (gps['bearing'] as num).toDouble(),
+            accuracy: (gps['accuracy'] as num).toDouble(),
+            direction: '',
+            gpsStatus: 1,
+          );
+          _controller.add(vector);
+        } else {
+          timer.cancel();
+        }
+      });
+      return;
+    }
+
+    Stream<Position> positionStreamLocal;
 
     if (positionStream != null) {
-      stream = positionStream;
+      positionStreamLocal = positionStream;
     } else {
       // Request permissions when using the real geolocator stream.
       bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
@@ -52,22 +85,22 @@ class LocationManager {
         throw Exception('Location permissions are permanently denied');
       }
 
-      stream = Geolocator.getPositionStream(
+      positionStreamLocal = Geolocator.getPositionStream(
           locationSettings: LocationSettings(
         accuracy: LocationAccuracy.best,
         distanceFilter: minDistance.round(),
-        timeLimit: Duration(milliseconds: minTime),
       ));
     }
 
-    _subscription = stream.listen(_onPosition);
+    _subscription = positionStreamLocal.listen(_onPosition);
   }
 
   void _onPosition(Position position) {
     final vector = VectorData(
       longitude: position.longitude,
       latitude: position.latitude,
-      speed: position.speed,
+      // Geolocator reports speed in m/s; convert to km/h for VectorData.
+      speed: position.speed * 3.6,
       bearing: position.heading,
       accuracy: position.accuracy,
       direction: '',
@@ -76,9 +109,19 @@ class LocationManager {
     _controller.add(vector);
   }
 
-  /// Stop listening to location updates and close the stream.
+  /// Stop listening to location updates but keep the stream open for restart.
   Future<void> stop() async {
+    if (!_running) return;
     await _subscription?.cancel();
+    _subscription = null;
+    _gpxTimer?.cancel();
+    _gpxTimer = null;
+    _running = false;
+  }
+
+  /// Permanently close the stream controller and cancel any listeners.
+  Future<void> dispose() async {
+    await stop();
     await _controller.close();
   }
 }

--- a/lib/ui/actions_page.dart
+++ b/lib/ui/actions_page.dart
@@ -9,7 +9,13 @@ import '../app_controller.dart';
 /// were stacked vertically.
 class ActionsPage extends StatelessWidget {
   final AppController controller;
-  const ActionsPage({super.key, required this.controller});
+  final VoidCallback onFinished;
+
+  const ActionsPage({
+    super.key,
+    required this.controller,
+    required this.onFinished,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -20,12 +26,18 @@ class ActionsPage extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildButton('Start', controller.start),
+            _buildButton('Start', () async {
+              await controller.start();
+              onFinished();
+            }),
             const SizedBox(height: 16),
-            _buildButton('Stop', controller.stop),
+            _buildButton('Stop', () async {
+              await controller.stop();
+              onFinished();
+            }),
             const SizedBox(height: 16),
             _buildButton('Exit', () async {
-              await controller.stop();
+              await controller.dispose();
               SystemNavigator.pop();
             }),
           ],
@@ -38,7 +50,9 @@ class ActionsPage extends StatelessWidget {
     return SizedBox(
       height: 80,
       child: ElevatedButton(
-        onPressed: onPressed,
+        onPressed: () async {
+          await onPressed();
+        },
         child: Text(label, style: const TextStyle(fontSize: 32)),
       ),
     );

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -23,11 +23,16 @@ class _HomePageState extends State<HomePage> {
   int _index = 0;
   late final List<Widget> _pages;
 
+  void _showMain() => setState(() => _index = 1);
+
   @override
   void initState() {
     super.initState();
     _pages = [
-      ActionsPage(controller: widget.controller),
+      ActionsPage(
+        controller: widget.controller,
+        onFinished: _showMain,
+      ),
       DashboardPage(
         calculator: widget.controller.calculator,
         arStatus: widget.controller.arStatusNotifier,
@@ -41,7 +46,7 @@ class _HomePageState extends State<HomePage> {
 
   @override
   void dispose() {
-    widget.controller.stop();
+    widget.controller.dispose();
     super.dispose();
   }
 

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -1,0 +1,22 @@
+import 'package:test/test.dart';
+import 'package:workspace/app_controller.dart';
+import 'package:geolocator/geolocator.dart';
+
+void main() {
+  test('start starts all services and stop terminates them', () async {
+    final controller = AppController();
+    await controller.start(positionStream: const Stream<Position>.empty());
+
+    expect(controller.gps.isRunning, isTrue);
+    expect(controller.locationManager.isRunning, isTrue);
+    expect(controller.calculator.isRunning, isTrue);
+
+    await controller.stop();
+
+    expect(controller.gps.isRunning, isFalse);
+    expect(controller.locationManager.isRunning, isFalse);
+    expect(controller.calculator.isRunning, isFalse);
+
+    await controller.dispose();
+  });
+}

--- a/test/location_manager_test.dart
+++ b/test/location_manager_test.dart
@@ -10,7 +10,8 @@ void main() {
     final controller = StreamController<Position>();
     final manager = LocationManager();
 
-    manager.start(positionStream: controller.stream);
+    await manager.start(positionStream: controller.stream);
+    expect(manager.isRunning, isTrue);
 
     final future = manager.stream.first;
 
@@ -29,12 +30,24 @@ void main() {
 
     expect(data.longitude, 1.0);
     expect(data.latitude, 2.0);
-    expect(data.speed, 3.0);
+    expect(data.speed, closeTo(10.8, 1e-9));
     expect(data.bearing, 4.0);
     expect(data.accuracy, 5.0);
 
     await manager.stop();
+    expect(manager.isRunning, isFalse);
     await controller.close();
+    await manager.dispose();
+  });
+
+  test('location manager can replay GPX file', () async {
+    final manager = LocationManager();
+    await manager.start(gpxFile: 'gpx/nordspange_tr2.gpx', minTime: 1);
+    final sample = await manager.stream.first;
+    expect(sample.latitude, closeTo(52.54380991, 1e-6));
+    expect(sample.longitude, closeTo(13.27306718, 1e-6));
+    await manager.stop();
+    await manager.dispose();
   });
 }
 


### PR DESCRIPTION
## Summary
- Guard rectangle calculator start method to avoid multiple stream subscriptions
- Remove geolocator `timeLimit` to prevent startup timeout
- Allow the location manager to replay GPX tracks or device GPS and convert speeds to km/h
- Expose optional GPX playback in the app controller and fix start button callback
- Verify GPX playback and speed conversion in tests
- Navigate back to dashboard after start/stop, add exit button, and streamline GPS lifecycle
- Track running state of GPS, location manager and calculator so start/stop orchestrates all services
- Add tests exercising start/stop lifecycle

## Testing
- `dart format lib/app_controller.dart lib/gps_thread.dart lib/location_manager.dart lib/rectangle_calculator.dart test/location_manager_test.dart test/app_controller_test.dart` *(command not found)*
- `dart test` *(command not found)*
- `apt-get install -y dart` *(Unable to locate package)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5381dea8832c8ce772a94f3b1c72