### PR TITLE
Lighten bottom navigation bar

### DIFF
--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -55,6 +55,9 @@ class _HomePageState extends State<HomePage> {
     return Scaffold(
       body: IndexedStack(index: _index, children: _pages),
       bottomNavigationBar: BottomNavigationBar(
+        backgroundColor: Colors.black54,
+        selectedItemColor: Colors.white,
+        unselectedItemColor: Colors.white70,
         currentIndex: _index,
         onTap: (i) => setState(() => _index = i),
         items: const [


### PR DESCRIPTION
## Summary
- Lighten bottom navigation bar background and icon colors for improved visibility

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c229e75a8832ca1433b7177f7e433