### PR TITLE
Fix popup marker options for updated flutter_map_marker_popup

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -98,34 +98,36 @@ class _MapPageState extends State<MapPage> {
             userAgentPackageName: 'com.example.speedcamwarner',
           ),
           if (_gpsMarker != null) MarkerLayer(markers: [_gpsMarker!]),
-          PopupMarkerLayerWidget(
+          PopupMarkerLayer(
             options: PopupMarkerLayerOptions(
               popupController: _popupController,
               markers: _cameraMarkers,
-              popupBuilder: (context, marker) {
-                final cam = _markerData[marker];
-                if (cam == null) return const SizedBox.shrink();
-                final types = <String>[
-                  if (cam.fixed) 'fixed',
-                  if (cam.traffic) 'traffic',
-                  if (cam.mobile) 'mobile',
-                  if (cam.predictive) 'predictive',
-                ].join(', ');
-                return Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(cam.name.isNotEmpty ? cam.name : 'Speed camera'),
-                        if (types.isNotEmpty)
-                          Text(types, style: const TextStyle(fontSize: 12)),
-                      ],
+              popupDisplayOptions: PopupDisplayOptions(
+                builder: (context, marker) {
+                  final cam = _markerData[marker];
+                  if (cam == null) return const SizedBox.shrink();
+                  final types = <String>[
+                    if (cam.fixed) 'fixed',
+                    if (cam.traffic) 'traffic',
+                    if (cam.mobile) 'mobile',
+                    if (cam.predictive) 'predictive',
+                  ].join(', ');
+                  return Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(cam.name.isNotEmpty ? cam.name : 'Speed camera'),
+                          if (types.isNotEmpty)
+                            Text(types, style: const TextStyle(fontSize: 12)),
+                        ],
+                      ),
                     ),
-                  ),
-                );
-              },
+                  );
+                },
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- adapt to flutter_map_marker_popup 8 by using PopupDisplayOptions and PopupMarkerLayer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3a174944832c975fc34d9d603764