### PR TITLE
Add GPX simulation mode and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ This is a Flutter-based Android application that predicts the nearest speed came
 3. Run `flutter pub get` to install dependencies.
 4. Use `flutter run` to launch the app on an emulator or device.
 
+## GPX Simulation
+For development and testing without relying on a real GPS receiver, the app can
+replay coordinates from a GPX track. On the **Actions** page press **Start (GPX)**
+to launch the app using the sample track located at `gpx/nordspange_tr2.gpx`.
+
 ## Project Structure
 - `lib/`: Contains the main application code.
 - `assets/`: Stores static assets like images and JSON files.

--- a/lib/ui/actions_page.dart
+++ b/lib/ui/actions_page.dart
@@ -32,6 +32,11 @@ class ActionsPage extends StatelessWidget {
               onFinished();
             }),
             const SizedBox(height: 16),
+            _buildButton(context, 'Start (GPX)', () async {
+              await controller.start(gpxFile: 'gpx/nordspange_tr2.gpx');
+              onFinished();
+            }),
+            const SizedBox(height: 16),
             _buildButton(context, 'Stop', () async {
               await controller.stop();
               onFinished();

--- a/test/app_controller_test.dart
+++ b/test/app_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 import 'package:workspace/app_controller.dart';
+import 'package:workspace/rectangle_calculator.dart';
 import 'package:geolocator/geolocator.dart';
 
 void main() {
@@ -17,6 +18,16 @@ void main() {
     expect(controller.locationManager.isRunning, isFalse);
     expect(controller.calculator.isRunning, isFalse);
 
+    await controller.dispose();
+  });
+
+  test('AppController can replay a GPX track', () async {
+    final controller = AppController();
+    await controller.start(gpxFile: 'gpx/nordspange_tr2.gpx');
+    final VectorData sample = await controller.gps.stream.first;
+    expect(sample.latitude, closeTo(52.54380991, 1e-6));
+    expect(sample.longitude, closeTo(13.27306718, 1e-6));
+    await controller.stop();
     await controller.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- allow starting the app with a sample GPX track to simulate GPS updates
- document GPX simulation in the README
- add an integration test for AppController using GPX data

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3e25b270832cbd2f01dc69244bed