### PR TITLE
Load GPX data from asset bundle

### DIFF
--- a/lib/gpx_loader.dart
+++ b/lib/gpx_loader.dart
@@ -1,0 +1,3 @@
+import 'gpx_loader_io.dart' if (dart.library.ui) 'gpx_loader_flutter.dart';
+
+Future<String> loadGpx(String path) => loadGpxImpl(path);

--- a/lib/gpx_loader_flutter.dart
+++ b/lib/gpx_loader_flutter.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+Future<String> loadGpxImpl(String path) async {
+  return rootBundle.loadString(path);
+}

--- a/lib/gpx_loader_io.dart
+++ b/lib/gpx_loader_io.dart
@@ -1,0 +1,5 @@
+import 'dart:io';
+
+Future<String> loadGpxImpl(String path) async {
+  return File(path).readAsString();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ flutter:
   assets:
     - python/sounds/
     - images/
+    - gpx/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- replay GPX routes by loading samples from Flutter assets
- add platform-aware GPX loader to support file and asset sources
- bundle `gpx/` directory as Flutter assets

## Testing
- `dart test test/location_manager_test.dart test/app_controller_test.dart` *(fails: Because workspace depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available))*

------
https://chatgpt.com/codex/tasks/task_e_689c407ff004832ca3f75e9b54f0337b