### PR TITLE
Fix HSVColor reference in dashboard

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -246,7 +246,7 @@ class _DashboardPageState extends State<DashboardPage> {
     // produce more fine-grained color changes around the neutral (green)
     // point.
     final hue = 240 - (ratio * 240);
-    final color = ui.HSVColor.fromAHSV(1.0, hue, 1.0, 1.0).toColor();
+    final color = HSVColor.fromAHSV(1.0, hue, 1.0, 1.0).toColor();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [


### PR DESCRIPTION
## Summary
- use Flutter's `HSVColor` directly instead of an undefined `ui.HSVColor`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c4fa5abbc832c8a114293ed22b31c