### PR TITLE
Port Python config to Dart and harden camera utilities

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -1,0 +1,96 @@
+{
+  "main": {
+    "poi_distance": 50
+  },
+  "calculator": {
+    "max_download_time": 20,
+    "osm_timeout": 20,
+    "osm_timeout_motorway": 30,
+    "dos_attack_prevention_interval_downloads": 30,
+    "speed_cam_look_ahead_distance": 300,
+    "construction_area_lookahead_distance": 30,
+    "construction_area_startup_trigger_max": 60,
+    "initial_rect_distance": 3,
+    "speed_influence_on_rect_boundary": 110,
+    "current_rect_angle": 90,
+    "fallback_rect_angle": 123,
+    "zoom": 17,
+    "max_cross_roads": 3,
+    "disable_road_lookup": false,
+    "cameras_look_ahead_mode": true,
+    "alternative_road_lookup": true,
+    "use_only_one_extrapolated_rect": false,
+    "consider_backup_rects": true,
+    "dismiss_pois": true,
+    "enable_ordered_rects_extrapolated": true,
+    "max_number_extrapolated_rects": 6,
+    "maxspeed_countries": {
+      "AT:motorway": 130,
+      "DE:motorway": "UNLIMITED",
+      "motorway_general": 130
+    },
+    "road_classes_to_speed": {
+      "trunk": 100,
+      "primary": 100,
+      "unclassified": 70,
+      "secondary": 50,
+      "tertiary": 50,
+      "service": 50,
+      "track": 30,
+      "residential": 30,
+      "bus_guideway": 30,
+      "escape": 30,
+      "bridleway": 30,
+      "living_street": 20,
+      "path": 20,
+      "cycleway": 20,
+      "pedestrian": 10,
+      "footway": 10,
+      "road": 10,
+      "urban": 50
+    }
+  },
+  "sql": {
+    "u_time_from_cloud": 60,
+    "init_time_from_cloud": 10,
+    "u_time_from_db": 30
+  },
+  "speedCamWarner": {
+    "enable_inside_relevant_angle_feature": true,
+    "emergency_angle_distance": 150,
+    "delete_cameras_outside_lookahead_rectangle": true,
+    "max_absolute_distance": 300000,
+    "max_storage_time": 28800,
+    "traversed_cameras_interval": 3,
+    "max_dismiss_counter": 5,
+    "max_distance_to_future_camera": 5000,
+    "baseurl": "http://overpass-api.de/api/interpreter?",
+    "querystring1": "data=[out:json];",
+    "querystring2": "way[\"highway\"~\".\"](around:5,",
+    "querystring3": "50.7528080,2.0377858",
+    "querystring4": ");out geom;"
+  },
+  "accusticWarner": {
+    "ai_voice_prompts": true
+  },
+  "gpsConsumer": {
+    "display_miles": false
+  },
+  "gpsThread": {
+    "gps_test_data": true,
+    "max_gps_entries": 50000,
+    "gpx_file": "python/gpx/Weekend_Karntner_5SeenTour.gpx",
+    "gps_treshold": 40,
+    "gps_inaccuracy_treshold": 4,
+    "recording": false
+  },
+  "osmWrapper": {
+    "draw_rects": true
+  },
+  "osmWrapperPorted": {
+    "draw_rects": true
+  },
+  "logger": {
+    "always_log_to_stdout": false
+  }
+}

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+
+/// Loads configuration values from `assets/config.json` and provides
+/// convenient lookup helpers.  The JSON file consolidates options from the
+/// original Python `set_configs()` methods so the Flutter port can adjust its
+/// behaviour without code changes.
+class AppConfig {
+  static Map<String, dynamic> _values = {};
+
+  /// Load the configuration from the bundled asset. Should be called once
+  /// during application start before any configuration values are accessed.
+  static Future<void> load() async {
+    final jsonStr = await rootBundle.loadString('assets/config.json');
+    _values = jsonDecode(jsonStr) as Map<String, dynamic>;
+  }
+
+  /// Retrieve a configuration value using dot separated [path] notation.
+  /// Returns `null` if the key does not exist or if [T] does not match.
+  static T? get<T>(String path) {
+    final segments = path.split('.');
+    dynamic current = _values;
+    for (final segment in segments) {
+      if (current is Map<String, dynamic> && current.containsKey(segment)) {
+        current = current[segment];
+      } else {
+        return null;
+      }
+    }
+    return current as T?;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'overspeed_checker.dart';
 import 'rectangle_calculator.dart';
 import 'linked_list_generator.dart';
 import 'app_controller.dart';
+import 'config.dart';
 import 'ui/home.dart';
 
 /// Entry point of the SpeedCamWarner application.
@@ -15,7 +16,9 @@ import 'ui/home.dart';
 /// In this Flutter port we provide a [HomePage] with a bottom navigation bar
 /// and multiple dedicated screens while background modules are coordinated by
 /// [AppController].
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await AppConfig.load();
   runApp(SpeedCamWarnerApp());
 }
 

--- a/lib/poi_reader.dart
+++ b/lib/poi_reader.dart
@@ -6,7 +6,8 @@ import 'package:sqlite3/sqlite3.dart' as sqlite;
 import 'logger.dart';
 import 'rect.dart';
 import 'service_account.dart';
-import 'rectangle_calculator.dart' show SpeedCameraEvent, RectangleCalculatorThread;
+import 'rectangle_calculator.dart'
+    show SpeedCameraEvent, RectangleCalculatorThread;
 import 'thread_base.dart';
 import 'gps_producer.dart';
 
@@ -150,7 +151,7 @@ class POIReader extends Logger {
     for (final camTuple in poiRawData!) {
       final x = _decodeMorton2X(camTuple[1] as int);
       final y = _decodeMorton2Y(camTuple[1] as int);
-      final longLat = calculator.tile2longlat(x, y, 17);
+      final longLat = calculator.tile2longlat(x.toDouble(), y.toDouble(), 17);
       final longitude = longLat[0];
       final latitude = longLat[1];
 
@@ -206,7 +207,8 @@ class POIReader extends Logger {
     String cameraType,
   ) {
     printLogLine(
-        'Propagating $cameraType camera (${longitude.toStringAsFixed(5)}, ${latitude.toStringAsFixed(5)})');
+      'Propagating $cameraType camera (${longitude.toStringAsFixed(5)}, ${latitude.toStringAsFixed(5)})',
+    );
     speedCamQueue.produce({
       'bearing': 0.0,
       'stable_ccp': true,
@@ -277,10 +279,12 @@ class POIReader extends Logger {
   }
 
   void _updateOsmWrapper({String cameraSource = 'cloud'}) {
-    final processingDict =
-        cameraSource == 'cloud' ? speedCamDict : speedCamDictDb;
-    final processingList =
-        cameraSource == 'cloud' ? speedCamList : speedCamListDb;
+    final processingDict = cameraSource == 'cloud'
+        ? speedCamDict
+        : speedCamDictDb;
+    final processingList = cameraSource == 'cloud'
+        ? speedCamList
+        : speedCamListDb;
 
     if (processingDict.isNotEmpty) {
       processingList.add(Map<String, List<dynamic>>.from(processingDict));
@@ -395,16 +399,18 @@ class POIReader extends Logger {
 
     poiRect?.deleteRect();
 
-    var direction = gpsProducer.get_direction();
+    String? direction = gpsProducer.get_direction();
     var lonLat = gpsProducer.get_lon_lat();
-    var longitude = lonLat[0];
-    var latitude = lonLat[1];
+    double longitude = lonLat[0];
+    double latitude = lonLat[1];
 
     if (direction == '-' || direction == null) {
-      if (lastValidDrivingDirection != null && lastValidLongitude != null) {
+      if (lastValidDrivingDirection != null &&
+          lastValidLongitude != null &&
+          lastValidLatitude != null) {
         direction = lastValidDrivingDirection;
-        longitude = lastValidLongitude;
-        latitude = lastValidLatitude;
+        longitude = lastValidLongitude!;
+        latitude = lastValidLatitude!;
       } else {
         printLogLine(' Waiting for valid direction once');
         return;
@@ -421,7 +427,7 @@ class POIReader extends Logger {
     final ytile = tiles[1];
 
     final polygon = calculator.createGeoJsonTilePolygon(
-      direction,
+      direction!,
       zoom,
       xtile,
       ytile,
@@ -436,7 +442,7 @@ class POIReader extends Logger {
     final pt1 = calculator.longlat2tile(latMin, lonMin, zoom);
     final pt2 = calculator.longlat2tile(latMax, lonMax, zoom);
     poiRect = calculator.calculate_rectangle_border(pt1, pt2);
-    poiRect?.setRectangleIdent(direction);
+    poiRect?.setRectangleIdent(direction!);
     poiRect?.setRectangleString('POIRECT');
 
     final rectangleRadius = calculator.calculate_rectangle_radius(

--- a/lib/service_account.dart
+++ b/lib/service_account.dart
@@ -133,7 +133,7 @@ class ServiceAccount {
     final driveApi = drive.DriveApi(client);
     final fname = uploadFileName ?? fileName;
     try {
-      final file = await driveApi.files.get(id, $fields: 'parents');
+      final drive.File file = await driveApi.files.get(id, $fields: 'parents');
       final currentParents = (file.parents ?? []).join(',');
       final media = drive.Media(
         File(fname).openRead(),
@@ -165,10 +165,12 @@ class ServiceAccount {
   ) async {
     final api = drive.DriveApi(client);
     try {
-      final media = await api.files.get(
-        fileId,
-        downloadOptions: drive.DownloadOptions.fullMedia,
-      );
+      final drive.Media media =
+          await api.files.get(
+                fileId,
+                downloadOptions: drive.DownloadOptions.fullMedia,
+              )
+              as drive.Media;
       final data = await media.stream.fold<List<int>>(
         [],
         (buffer, bytes) => buffer..addAll(bytes),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ flutter:
     - python/sounds/
     - images/
     - gpx/
+    - assets/config.json
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- alias overspeed thread to avoid ThreadCondition collisions
- add compatibility helpers and camera counters to rectangle calculator
- guard nullable values when loading POIs and managing camera queue
- type Google Drive interactions for parents and media streams
- centralize configuration loading from assets/config.json

## Testing
- `python -m json.tool assets/config.json`
- `dart format lib/app_controller.dart lib/config.dart lib/main.dart lib/poi_reader.dart lib/rectangle_calculator.dart lib/service_account.dart lib/speed_cam_warner.dart`
- `dart analyze` *(fails: missing Flutter packages and tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c51a860dc832c9b9472fc44bff4ea