### PR TITLE
Fix queue type imports and Google Drive file cast

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -14,6 +14,7 @@ import 'voice_prompt_thread.dart';
 import 'overspeed_thread.dart' as overspeed;
 import 'overspeed_checker.dart';
 import 'config.dart';
+import 'thread_base.dart';
 
 /// Central place that wires up background modules and manages their
 /// lifecycles.  The original Python project spawned numerous threads; in

--- a/lib/service_account.dart
+++ b/lib/service_account.dart
@@ -133,7 +133,8 @@ class ServiceAccount {
     final driveApi = drive.DriveApi(client);
     final fname = uploadFileName ?? fileName;
     try {
-      final drive.File file = await driveApi.files.get(id, $fields: 'parents');
+      final drive.File file =
+          await driveApi.files.get(id, $fields: 'parents') as drive.File;
       final currentParents = (file.parents ?? []).join(',');
       final media = drive.Media(
         File(fname).openRead(),


### PR DESCRIPTION
## Summary
- import `thread_base.dart` in `AppController` so SpeedCamQueue and MapQueue types resolve
- cast Google Drive API result to `drive.File` in `ServiceAccount`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5ce6b4c8832ca2a0b578e210c982