### PR TITLE
Forward GPS accuracy status to voice prompts

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -21,7 +21,10 @@ import 'thread_base.dart';
 /// Dart we keep long lived objects and expose explicit [start] and [stop]
 /// hooks so the Flutter UI can control them.
 class AppController {
-  AppController() {
+  AppController()
+      : voicePromptQueue = VoicePromptQueue(),
+        locationManager = LocationManager() {
+    gps = GpsThread(voicePromptQueue: voicePromptQueue);
     overspeedChecker = OverspeedChecker();
     overspeedThread = overspeed.OverspeedThread(
       cond: overspeed.ThreadCondition(),
@@ -67,13 +70,13 @@ class AppController {
   }
 
   /// Handles GPS sampling.
-  final GpsThread gps = GpsThread();
+  late final GpsThread gps;
 
   /// Provides real position updates using the device's sensors.
-  final LocationManager locationManager = LocationManager();
+  final LocationManager locationManager;
 
   /// Shared queue for delivering voice prompt entries.
-  final VoicePromptQueue voicePromptQueue = VoicePromptQueue();
+  final VoicePromptQueue voicePromptQueue;
 
   /// Performs rectangle calculations and camera lookups.
   late final RectangleCalculatorThread calculator;

--- a/test/gps_thread_test.dart
+++ b/test/gps_thread_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:workspace/gps_thread.dart';
 import 'package:workspace/rectangle_calculator.dart';
+import 'package:workspace/voice_prompt_queue.dart';
 
 void main() {
   test('gps thread feeds rectangle calculator', () async {
@@ -33,5 +34,34 @@ void main() {
 
     await gps.stop();
     await calc.dispose();
+  });
+
+  test('gps thread forwards gps accuracy to voice queue', () async {
+    final queue = VoicePromptQueue();
+    final gps = GpsThread(voicePromptQueue: queue, accuracyThreshold: 10);
+    gps.start();
+    gps.addSample(VectorData(
+        longitude: 1.0,
+        latitude: 1.0,
+        speed: 0,
+        bearing: 0,
+        direction: 'Main',
+        gpsStatus: 1,
+        accuracy: 5));
+    final first = await queue.consumeItems().timeout(const Duration(milliseconds: 100));
+    expect(first, 'GPS_ON');
+
+    gps.addSample(VectorData(
+        longitude: 1.0,
+        latitude: 1.0,
+        speed: 0,
+        bearing: 0,
+        direction: 'Main',
+        gpsStatus: 1,
+        accuracy: 20));
+    final second = await queue.consumeItems().timeout(const Duration(milliseconds: 100));
+    expect(second, 'GPS_LOW');
+
+    await gps.stop();
   });
 }

--- a/test/voice_prompt_thread_test.dart
+++ b/test/voice_prompt_thread_test.dart
@@ -38,6 +38,8 @@ void main() {
     );
     final sound = thread.mapVoiceEntryToSound('GPS_OFF');
     expect(sound, contains('gps_off.wav'));
+    final low = thread.mapVoiceEntryToSound('GPS_LOW');
+    expect(low, contains('gps_weak.wav'));
   });
 
   test('setConfigs toggles aiVoicePrompts', () {


### PR DESCRIPTION
## Summary
- extend `GpsThread` with optional `VoicePromptQueue` and emit `GPS_ON/LOW/OFF` events based on accuracy
- wire `AppController` to supply the voice prompt queue to the GPS thread
- test coverage for GPS accuracy signalling and voice prompt mappings

## Testing
- ⚠️ `dart format lib/gps_thread.dart lib/app_controller.dart test/gps_thread_test.dart` *(command not found: dart)*
- ⚠️ `dart test` *(command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_689c5dfc7544832c8b6dd86f882e25c0