### PR TITLE
Integrate OSM wrapper with AppController

### DIFF
--- a/lib/osm_thread.dart
+++ b/lib/osm_thread.dart
@@ -1,0 +1,39 @@
+import 'osm_wrapper.dart';
+import 'thread_base.dart';
+
+/// Minimal thread consuming map updates and forwarding them to [osmWrapper].
+///
+/// The original project used a separate OS thread to update the map display.
+/// In this Dart port the heavy lifting is omitted – the thread merely drains
+/// the [MapQueue] so producers don't block and can be cleanly shut down.
+class OsmThread {
+  final Maps osmWrapper;
+  final MapQueue<dynamic> mapQueue;
+  final ThreadCondition cond;
+
+  OsmThread({
+    required this.osmWrapper,
+    required this.mapQueue,
+    ThreadCondition? cond,
+  }) : cond = cond ?? ThreadCondition(false);
+
+  /// Continuously consume map updates until [stop] is called.
+  Future<void> run() async {
+    while (!(cond.terminate)) {
+      final item = await mapQueue.consume();
+      if (item == 'EXIT') {
+        break;
+      }
+      // Map rendering is not implemented in this port; updates are ignored.
+    }
+    // ignore: avoid_print
+    print('OsmThread terminating');
+  }
+
+  /// Signal the thread to terminate and unblock any pending [consume] call.
+  Future<void> stop() async {
+    cond.setTerminateState(true);
+    mapQueue.produce('EXIT');
+  }
+}
+


### PR DESCRIPTION
## Summary
- wire up Maps-based OSM wrapper and thread in AppController
- pass OSM wrapper into SpeedCamWarner
- provide lightweight OsmThread to drain map updates

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5e030de0832caaf06ff9d54f2b3a