### PR TITLE
Initialize AR widget with injected voice queue

### DIFF
--- a/lib/ar_layout.dart
+++ b/lib/ar_layout.dart
@@ -32,7 +32,7 @@ class EdgeDetectState extends State<EdgeDetect> {
   bool cameraConnected = false;
   String _cameraDirection = 'back';
 
-  VoicePromptQueue voicePromptQueue = VoicePromptQueue();
+  late VoicePromptQueue voicePromptQueue;
   dynamic g;
   dynamic speedL;
   Function(String message)? _logViewer;

--- a/lib/ui/ar_page.dart
+++ b/lib/ui/ar_page.dart
@@ -18,6 +18,19 @@ class _ArPageState extends State<ArPage> {
   final GlobalKey<EdgeDetectState> _arKey = GlobalKey<EdgeDetectState>();
   bool _running = false;
 
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _arKey.currentState?.init(
+        widget.controller.gps,
+        widget.controller,
+        widget.controller.voicePromptQueue,
+        null,
+      );
+    });
+  }
+
   Future<void> _toggleAr() async {
     if (_running) {
       await _arKey.currentState?.disconnectCamera();

--- a/test/voice_prompt_thread_test.dart
+++ b/test/voice_prompt_thread_test.dart
@@ -17,6 +17,21 @@ class FakeDialogflow {
   Future<String> detectIntent(String text) async => 'response:$text';
 }
 
+class TestVoicePromptThread extends VoicePromptThread {
+  final List<String> played = [];
+  TestVoicePromptThread({
+    required super.voicePromptQueue,
+    required super.dialogflowClient,
+    super.tts,
+    super.aiVoicePrompts,
+  });
+
+  @override
+  Future<void> playSound(String fileName) async {
+    played.add(fileName);
+  }
+}
+
 void main() {
   test('ai voice prompts speak dialogflow response', () async {
     final thread = VoicePromptThread(
@@ -66,5 +81,19 @@ void main() {
     thread.stop();
     await future;
     expect(tts.lastText, isNull);
+  });
+
+  test('ar events processed by voice thread', () async {
+    final queue = VoicePromptQueue();
+    final thread = TestVoicePromptThread(
+      voicePromptQueue: queue,
+      dialogflowClient: FakeDialogflow(),
+      tts: FakeTts(),
+      aiVoicePrompts: false,
+    );
+    queue.produceArStatus('AR_HUMAN');
+    final item = await queue.consumeItems();
+    await thread.process(item);
+    expect(thread.played, contains('human.wav'));
   });
 }


### PR DESCRIPTION
## Summary
- Initialize `EdgeDetect` in `ArPage` with GPS, controller, and voice prompt queue after the first frame.
- Remove the default `VoicePromptQueue` in `EdgeDetectState` so it uses the injected queue.
- Add unit test ensuring AR events from the queue are processed by `VoicePromptThread`.

## Testing
- `dart test` *(fails: command not found)*
- `apt-get install dart -y` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689c5e1cfd80832cb13ed7adc869d41d