### PR TITLE
docs: clarify service account and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ For development and testing without relying on a real GPS receiver, the app can
 replay coordinates from a GPX track. On the **Actions** page press **Start (GPX)**
 to launch the app using the sample track located at `gpx/nordspange_tr2.gpx`.
 
+## Cloud data and rate limiting
+
+The application downloads speed camera and construction zone information from a
+cloud service. Access to this data requires a valid Google service account JSON
+file placed at `python/service_account/<your-service-account>.json`. Without this
+file the log will show messages like `Service account file not found` and the
+app will fall back to the limited data bundled with the repository.
+
+To avoid excessive network traffic the lookahead requests are rate limited. The
+interval is controlled by the `dosAttackPreventionIntervalDownloads` variable in
+`lib/rectangle_calculator.dart` (default `30` seconds). Adjust this value if you
+need more frequent updates during development.
+
 ## Project Structure
 - `lib/`: Contains the main application code.
 - `assets/`: Stores static assets like images and JSON files.


### PR DESCRIPTION
## Summary
- document that speed camera and construction zone data require a Google service account JSON
- explain lookahead rate limiting and how to adjust `dosAttackPreventionIntervalDownloads`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f57ea90832caa3b4b173dd09759