### PR TITLE
Wire AR page return callback

### DIFF
--- a/lib/ar_layout.dart
+++ b/lib/ar_layout.dart
@@ -319,11 +319,18 @@ class _DetectionPainter extends CustomPainter {
 }
 
 class ARLayout extends StatefulWidget {
-  const ARLayout({super.key, this.sm, this.mainApp, this.initArgs});
+  const ARLayout({
+    super.key,
+    this.sm,
+    this.mainApp,
+    this.initArgs,
+    this.onReturn,
+  });
 
   final dynamic sm;
   final AppController? mainApp;
   final List<dynamic>? initArgs;
+  final VoidCallback? onReturn;
 
   @override
   State<ARLayout> createState() => _ARLayoutState();
@@ -388,7 +395,7 @@ class _ARLayoutState extends State<ARLayout> {
                 statusNotifier: widget.mainApp?.arStatusNotifier)),
         Positioned.fill(
           child: ButtonsLayout(
-            onReturn: callbackReturn,
+            onReturn: widget.onReturn ?? callbackReturn,
             onScreenshot: () => _edgeKey.currentState?.captureScreenshot(),
             onSelectCamera: _selectCamera,
             onConnectCamera: _connectCamera,

--- a/lib/ui/ar_page.dart
+++ b/lib/ui/ar_page.dart
@@ -50,7 +50,10 @@ class _ArPageState extends State<ArPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: ARLayout(mainApp: widget.controller),
+      body: ARLayout(
+        mainApp: widget.controller,
+        onReturn: widget.onReturn,
+      ),
     );
   }
 }

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -38,7 +38,10 @@ class _HomePageState extends State<HomePage> {
         arStatus: widget.controller.arStatusNotifier,
       ),
       MapPage(calculator: widget.controller.calculator),
-      ArPage(controller: widget.controller),
+      ArPage(
+        controller: widget.controller,
+        onReturn: _showMain,
+      ),
       InfoPage(calculator: widget.controller.calculator),
       StatsPage(calculator: widget.controller.calculator),
     ];


### PR DESCRIPTION
## Summary
- propagate an optional return callback through ARLayout so AR view can signal when to exit
- connect ArPage and HomePage to provide the onReturn handler

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6740ba34832cadb8570f5f433fdc