### PR TITLE
chore: improve lookahead, logging and map icon

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -1289,6 +1289,10 @@ class RectangleCalculatorThread {
       ccpLat = latitude;
     }
 
+    logger.printLogLine(
+      'Lookahead for tiles ($xtile,$ytile) at ($ccpLat,$ccpLon)',
+    );
+
     // Process predictive cameras
     await processPredictiveCameras(ccpLon, ccpLat);
 
@@ -1326,11 +1330,14 @@ class RectangleCalculatorThread {
 
       final now = DateTime.now();
       final last = _lastLookaheadExecution[msg];
-      if (last != null &&
-          now.difference(last).inSeconds <
-              dosAttackPreventionIntervalDownloads) {
-        logger.printLogLine('Skipping $msg - rate limited');
-        continue;
+      if (last != null) {
+        final elapsed = now.difference(last).inMilliseconds / 1000;
+        if (elapsed < dosAttackPreventionIntervalDownloads) {
+          final wait = (dosAttackPreventionIntervalDownloads - elapsed)
+              .toStringAsFixed(1);
+          logger.printLogLine('Skipping $msg - rate limited (wait ${wait}s)');
+          continue;
+        }
       }
 
       if (msg == 'Construction area lookahead') {

--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -109,6 +109,7 @@ class SpeedCamWarner {
 
   // ------------------------------ threading -----------------------------
   Future<void> run() async {
+    print('SpeedCamWarner thread started');
     while (!(cond.terminate ?? false)) {
       var status = await process();
       if (status == 'EXIT') break;

--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -39,13 +39,14 @@ class _MapPageState extends State<MapPage> {
       point: _center,
       width: 40,
       height: 40,
-      child: Image.asset('images/gps.png'),
+      child: Image.asset('images/car.png'),
     );
     widget.calculator.positionNotifier.addListener(_updatePosition);
     _camSub = widget.calculator.cameras.listen(_onCameraEvent);
     _rectSub = widget.calculator.rectangles.listen(_onRect);
-    _constructionSub =
-        widget.calculator.constructions.listen(_onConstructionArea);
+    _constructionSub = widget.calculator.constructions.listen(
+      _onConstructionArea,
+    );
   }
 
   void _updatePosition() {
@@ -56,7 +57,7 @@ class _MapPageState extends State<MapPage> {
         point: _center,
         width: 40,
         height: 40,
-        child: Image.asset('images/gps.png'),
+        child: Image.asset('images/car.png'),
       );
     });
     // Recenter the map whenever the GPS position updates
@@ -165,7 +166,8 @@ class _MapPageState extends State<MapPage> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                                cam.name.isNotEmpty ? cam.name : 'Speed camera'),
+                              cam.name.isNotEmpty ? cam.name : 'Speed camera',
+                            ),
                             if (types.isNotEmpty)
                               Text(types, style: const TextStyle(fontSize: 12)),
                           ],


### PR DESCRIPTION
## Summary
- re-enable lookahead rate limiting and startup grace period with default intervals
- retain detailed debug logs and GPS car icon
- log SpeedCamWarner thread start for easier verification

## Testing
- `dart format lib/rectangle_calculator.dart` *(command not found; attempted install but package unavailable)*
- `dart test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c69a889a8832ca358682b7169a855