### PR TITLE
Ensure service account credentials are bundled and loadable

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ flutter:
     - images/
     - gpx/
     - assets/config.json
+    - python/service_account/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- Remove committed service account JSON and ensure it stays gitignored
- Bundle entire service account directory as an asset so credentials can be provided externally
- Improve service account loader to throw clear error when no credentials are found

## Testing
- ⚠️ `flutter test` *(bash: command not found: flutter)*
- ⚠️ `apt-get install -y flutter` *(E: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689c6a12c800832c8f2222c6dc570394