### PR TITLE
Filter OSM lookups by tag

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -1911,7 +1911,11 @@ class RectangleCalculatorThread {
     final bbox =
         '(${area.minLat},${area.minLon},${area.maxLat},${area.maxLon})';
     String query;
-    if (lookupType == 'node' && nodeId != null) {
+    if (lookupType == 'camera_ahead') {
+      query = '[out:json];node$bbox[highway=speed_camera];out;';
+    } else if (lookupType == 'distance_cam') {
+      query = '[out:json];node$bbox["some_distance_cam_tag"];out;';
+    } else if (lookupType == 'node' && nodeId != null) {
       query = '[out:json];node($nodeId);out;';
     } else {
       query = '[out:json];(node$bbox;);out;';

--- a/test/rectangle_calculator_methods_test.dart
+++ b/test/rectangle_calculator_methods_test.dart
@@ -177,7 +177,13 @@ void main() {
       'speedCamLookupAhead emits cameras and counts distance cams',
       () async {
         final calc = RectangleCalculatorThread();
+        final queries = <String>[];
         final mock = MockClient((req) async {
+          queries.add(
+            Uri.decodeQueryComponent(
+              req.url.queryParameters['data'] ?? '',
+            ),
+          );
           final body = jsonEncode({
             'elements': [
               {
@@ -198,6 +204,9 @@ void main() {
         final sub = calc.cameras.listen(events.add);
         await calc.speedCamLookupAhead(0, 0, 0, 0, client: mock);
         await Future.delayed(const Duration(milliseconds: 10));
+        expect(queries.length, equals(2));
+        expect(queries[0], contains('[highway=speed_camera]'));
+        expect(queries[1], contains('["some_distance_cam_tag"]'));
         expect(events.length, equals(1));
         expect(events.first.name, equals('A'));
         expect(events.first.fixed, isTrue);


### PR DESCRIPTION
## Summary
- restrict camera queries to speed_camera tag and distance camera tag in Overpass lookups
- verify speedCamLookupAhead sends tag-specific Overpass queries

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c84daaa8c832cb25148561705bbb1