### PR TITLE
Fix lookahead rectangle tile coordinates

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -718,9 +718,14 @@ class RectangleCalculatorThread {
     final double maxLat = latitude + deltaLat;
     final double minLon = longitude - deltaLon;
     final double maxLon = longitude + deltaLon;
-    // Store a Rect representation for geometric queries such as
-    // [Rect.pointInRect] or [Rect.pointsCloseToBorder].
-    lastRect = Rect(pointList: [minLon, minLat, maxLon, maxLat]);
+    // Store a Rect representation in tile coordinates for geometric queries
+    // such as [Rect.pointInRect] or [Rect.pointsCloseToBorder].
+    final minTile = longLatToTile(minLat, minLon, zoom);
+    final maxTile = longLatToTile(maxLat, maxLon, zoom);
+    lastRect = Rect(
+      pt1: Point(minTile.x, minTile.y),
+      pt2: Point(maxTile.x, maxTile.y),
+    );
     return GeoRect(
       minLat: minLat,
       minLon: minLon,

--- a/test/gps_thread_test.dart
+++ b/test/gps_thread_test.dart
@@ -27,10 +27,11 @@ void main() {
         gpsStatus: 1,
         accuracy: 5));
 
-    final rect = await completer.future
-        .timeout(const Duration(seconds: 1));
+    final rect =
+        await completer.future.timeout(const Duration(seconds: 1));
     expect(rect, isNotNull);
-    expect(calc.lastRect!.pointInRect(1.0, 1.0), isTrue);
+    final tiles = calc.longlat2tile(1.0, 1.0, calc.zoom);
+    expect(calc.lastRect!.pointInRect(tiles[0], tiles[1]), isTrue);
 
     await gps.stop();
     await calc.dispose();


### PR DESCRIPTION
## Summary
- compute lookahead rectangles in tile coordinates so inside checks work
- update tests to match tile-based rectangles

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8240af04832c91e2d257a352072c