### PR TITLE
Fix skipping of lookahead operations

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -644,8 +644,6 @@ class RectangleCalculatorThread {
     speedCamLookAheadDistance = lookAheadKm;
     constructionAreaLookaheadDistance = lookAheadKm;
     final GeoRect rect = _computeBoundingRect(latitude, longitude, lookAheadKm);
-    rectSpeedCamLookahead = lastRect;
-    rectConstructionAreasLookahead = lastRect;
     currentRectAngle = bearing;
     _rectangleStreamController.add(rect);
 
@@ -1368,6 +1366,11 @@ class RectangleCalculatorThread {
       await func(trigger, 1, xtile, ytile, ccpLon, ccpLat);
       logger.printLogLine('$msg lookup finished');
       _lastLookaheadExecution[msg] = DateTime.now();
+      if (msg == 'Speed Camera lookahead') {
+        rectSpeedCamLookahead = lastRect;
+      } else if (msg == 'Construction area lookahead') {
+        rectConstructionAreasLookahead = lastRect;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure lookahead rectangles are updated only after executing lookups
- avoid prematurely skipping lookahead operations when inside current rectangle

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c91899658832cbfce46fccaa6098c