### PR TITLE
Fix road name UI updates

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -1152,9 +1152,14 @@ class RectangleCalculatorThread {
       }
       lastRoadName = roadName;
       this.foundCombinedTags = foundCombinedTags;
+      updateRoadname(roadName, foundCombinedTags);
       return true;
     } else {
-      return lastRoadName != null;
+      if (lastRoadName != null) {
+        updateRoadname(lastRoadName, this.foundCombinedTags);
+        return true;
+      }
+      return false;
     }
   }
 

--- a/test/rectangle_calculator_methods_test.dart
+++ b/test/rectangle_calculator_methods_test.dart
@@ -56,6 +56,7 @@ void main() {
       );
       expect(updated, isTrue);
       expect(calc.lastRoadName, equals('Main St'));
+      expect(calc.roadName, equals('Main St'));
     });
 
     test('processMaxSpeed triggers overspeed checker', () {
@@ -88,6 +89,7 @@ void main() {
         treeGenerator: tree,
       );
       expect(calc.lastRoadName, equals('Main St'));
+      expect(calc.roadName, equals('Main St'));
       expect(calc.lastMaxSpeed, equals(50));
     });
 
@@ -290,6 +292,7 @@ void main() {
       final calc = _TestCalc();
       await calc.processLookAheadInterrupts();
       expect(calc.lastRoadName, equals('Test Road'));
+      expect(calc.roadName, equals('Test Road'));
       expect(calc.lastMaxSpeed, equals(''));
     });
 


### PR DESCRIPTION
## Summary
- ensure `processRoadName` updates the UI notifier and reuses the last known name
- extend tests to verify road name updates during cache and lookup operations

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c9f51a558832cbf2aac299ddbb7d8