### PR TITLE
Preserve map zoom level on position updates

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -60,8 +60,9 @@ class _MapPageState extends State<MapPage> {
         child: Image.asset('images/car.png'),
       );
     });
-    // Recenter the map whenever the GPS position updates
-    _mapController.move(_center, 15);
+    // Recenter the map whenever the GPS position updates while keeping the
+    // current zoom level so the user can zoom out if desired.
+    _mapController.move(_center, _mapController.zoom);
   }
 
   void _onCameraEvent(SpeedCameraEvent cam) {


### PR DESCRIPTION
## Summary
- Keep current zoom level when recentering map to allow zooming out from max level

## Testing
- `dart format lib/ui/map_page.dart` *(fails: command not found: dart)*
- `dart test` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689ca03ea3d4832ca59f1da4116ddb6f