### PR TITLE
Fix Overpass camera lookup query order

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -2008,9 +2008,9 @@ class RectangleCalculatorThread {
         '(${area.minLat},${area.minLon},${area.maxLat},${area.maxLon})';
     String query;
     if (lookupType == 'camera_ahead') {
-      query = '[out:json];node$bbox[highway=speed_camera];out;';
+      query = '[out:json];node[highway=speed_camera]$bbox;out;';
     } else if (lookupType == 'distance_cam') {
-      query = '[out:json];node$bbox["some_distance_cam_tag"];out;';
+      query = '[out:json];node["some_distance_cam_tag"]$bbox;out;';
     } else if (lookupType == 'node' && nodeId != null) {
       query = '[out:json];node($nodeId);out;';
     } else {


### PR DESCRIPTION
## Summary
- ensure bounding box follows tag filter when building Overpass API queries

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4390230832c92f165959d30867c