### PR TITLE
Fix Overpass request body encoding

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -2045,8 +2045,13 @@ class RectangleCalculatorThread {
               headers: {
                 'User-Agent': 'speedcamwarner-dart',
                 'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded',
               },
-              body: {'data': query},
+              // Using a raw string body rather than a Map avoids URL encoding of
+              // the query which can cause issues with some proxy setups.  The
+              // Overpass API expects the payload to be provided under the `data`
+              // key as form data.
+              body: 'data=$query',
             )
             .timeout(osmRequestTimeout);
         if (resp.statusCode == 200) {


### PR DESCRIPTION
## Summary
- send Overpass API query as form-encoded string and set content-type to avoid request hanging

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cac3f5c98832c940be5806713b969