### PR TITLE
Compute follow-up camera distance before updates and sync calculator state

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -382,6 +382,7 @@ class RectangleCalculatorThread {
   final ValueNotifier<String?> speedCamNotifier = ValueNotifier<String?>(null);
   final ValueNotifier<double?> speedCamDistanceNotifier =
       ValueNotifier<double?>(null);
+  final ValueNotifier<String?> camTextNotifier = ValueNotifier<String?>(null);
   final ValueNotifier<String?> cameraRoadNotifier = ValueNotifier<String?>(
     null,
   );
@@ -2270,6 +2271,7 @@ class RectangleCalculatorThread {
   String? get maxspeedStatus => maxspeedStatusNotifier.value;
   String? get speedCamWarning => speedCamNotifier.value;
   double? get speedCamDistance => speedCamDistanceNotifier.value;
+  String? get camText => camTextNotifier.value;
   String? get cameraRoad => cameraRoadNotifier.value;
 
   void updateMaxspeed(dynamic maxspeed, {List<double>? color}) {
@@ -2311,10 +2313,12 @@ class RectangleCalculatorThread {
   void updateMaxspeedStatus(String value) =>
       maxspeedStatusNotifier.value = value;
 
-  void updateSpeedCam(String warning) => speedCamNotifier.value = warning;
+void updateSpeedCam(String warning) => speedCamNotifier.value = warning;
 
-  void updateSpeedCamDistance(double? meter) =>
-      speedCamDistanceNotifier.value = meter;
+void updateSpeedCamDistance(double? meter) =>
+    speedCamDistanceNotifier.value = meter;
 
-  void updateCameraRoad(String? road) => cameraRoadNotifier.value = road;
+void updateCamText(String? text) => camTextNotifier.value = text;
+
+void updateCameraRoad(String? road) => cameraRoadNotifier.value = road;
 }


### PR DESCRIPTION
## Summary
- Recalculate distance to the active speed camera using current coordinates before triggering updates
- Propagate camera-in-progress status and camera text to the calculator thread to keep UI and predictions in sync

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ccd6c4d94832cb6dd890db88c1d5d