### PR TITLE
Fix speed history graph repaint logic

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -454,7 +454,7 @@ class _SpeedChartPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _SpeedChartPainter oldDelegate) =>
-      oldDelegate.history != history ||
+      !listEquals(oldDelegate.history, history) ||
       oldDelegate.lowThreshold != lowThreshold ||
       oldDelegate.highThreshold != highThreshold;
 }


### PR DESCRIPTION
## Summary
- Ensure speed history chart repaints when data changes by using `listEquals`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8a72eb04832c8473327cff5d4c8b