### PR TITLE
fix overpass query encoding

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -15,6 +15,13 @@ class AppConfig {
     _values = jsonDecode(jsonStr) as Map<String, dynamic>;
   }
 
+  /// Directly assign configuration [values]. Primarily intended for tests
+  /// where loading from the bundled asset is either undesirable or
+  /// impractical.  Existing values are replaced.
+  static void loadFromMap(Map<String, dynamic> values) {
+    _values = values;
+  }
+
   /// Retrieve a configuration value using dot separated [path] notation.
   /// Returns `null` if the key does not exist or if [T] does not match.
   static T? get<T>(String path) {

--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -2175,8 +2175,11 @@ class RectangleCalculatorThread {
               // Using a raw string body rather than a Map avoids URL encoding of
               // the query which can cause issues with some proxy setups.  The
               // Overpass API expects the payload to be provided under the `data`
-              // key as form data.
-              body: 'data=$query',
+              // key as form data.  Some configuration strings already include
+              // this prefix so ensure we don't duplicate it which would result
+              // in `data=data=...` and trigger HTTP 400 responses from the
+              // Overpass API.
+              body: query.startsWith('data=') ? query : 'data=$query',
             )
             .timeout(osmRequestTimeout);
         if (resp.statusCode == 200) {

--- a/test/rectangle_calculator_methods_test.dart
+++ b/test/rectangle_calculator_methods_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 import 'package:workspace/rectangle_calculator.dart';
+import 'package:workspace/config.dart';
 import 'package:workspace/linked_list_generator.dart';
 import 'package:workspace/rect.dart';
 import 'package:workspace/tree_generator.dart';
@@ -151,6 +152,36 @@ void main() {
       expect(result.success, isTrue);
       expect(result.elements, isNotNull);
       expect(result.elements!.length, equals(1));
+    });
+
+    test('triggerOsmLookup avoids duplicate data prefix', () async {
+      // Mimic configuration that already contains the `data=` prefix
+      AppConfig.loadFromMap({
+        'speedCamWarner': {
+          'querystring1': 'data=[out:json];',
+          'querystring2': 'node[highway=speed_camera]',
+          'querystring3': '(around:5,0,0)',
+          'querystring4': ';out;'
+        }
+      });
+
+      String? capturedBody;
+      final mock = MockClient((req) async {
+        capturedBody = req.body;
+        return http.Response(jsonEncode({'elements': []}), 200);
+      });
+
+      await calc.triggerOsmLookup(
+        const GeoRect(minLat: 0, minLon: 0, maxLat: 1, maxLon: 1),
+        client: mock,
+      );
+
+      // Ensure the request body contains exactly one `data=` prefix
+      expect(capturedBody, startsWith('data='));
+      expect(capturedBody, isNot(startsWith('data=data=')));
+
+      // Reset configuration for subsequent tests
+      AppConfig.loadFromMap({});
     });
 
     test('triggerOsmLookup retries on timeout and falls back to cache',


### PR DESCRIPTION
## Summary
- ensure Overpass API requests don't double prepend `data=` which caused HTTP 400 responses
- allow tests to override configuration values via `AppConfig.loadFromMap`
- add regression test to verify single `data=` prefix in Overpass request

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc68f6c70832cb95b8c3c3f7a73cc