### PR TITLE
Reposition status indicators to prevent camera overlap

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -153,8 +153,6 @@ class _DashboardPageState extends State<DashboardPage> {
           children: [
             _buildCameraInfo(),
             const SizedBox(height: 16),
-            _buildStatusRow(),
-            const SizedBox(height: 16),
             Expanded(
               child: Row(
                 children: [
@@ -172,6 +170,8 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
             ),
+            const SizedBox(height: 16),
+            _buildStatusRow(),
             if (_arStatus.isNotEmpty) ...[
               const SizedBox(height: 16),
               Text('AR: $_arStatus',
@@ -429,8 +429,11 @@ class _DashboardPageState extends State<DashboardPage> {
                 style: TextStyle(color: Colors.white70, fontSize: 16)),
             const SizedBox(height: 8),
             Expanded(
-              child: CustomPaint(
-                painter: _SpeedChartPainter(_speedHistory),
+              child: LayoutBuilder(
+                builder: (context, constraints) => CustomPaint(
+                  size: Size(constraints.maxWidth, constraints.maxHeight),
+                  painter: _SpeedChartPainter(_speedHistory),
+                ),
               ),
             ),
             const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- Move GPS/internet status row below main dashboard content so it no longer covers active speed camera info
- Give speed history chart an explicit size so it displays as a proper graph instead of a vertical line

## Testing
- `dart format lib/ui/dashboard.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc8d62880832c8571c08555b0ec1f