### PR TITLE
Broadcast marker removal events from Maps

### DIFF
--- a/lib/osm_wrapper.dart
+++ b/lib/osm_wrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'config.dart';
 
 class Maps {
@@ -10,6 +12,14 @@ class Maps {
   double? accuracy;
   List<dynamic> geoBoundsExtrapolated = [];
   List<dynamic> geoBounds = [];
+
+  final _markerRemovalController =
+      StreamController<MarkerRemovalEvent>.broadcast();
+
+  /// Stream of marker removal events emitted when obsolete cameras need to
+  /// disappear from the map.
+  Stream<MarkerRemovalEvent> get markerRemovals =>
+      _markerRemovalController.stream;
 
   void setCalculatorThread(dynamic calculator) {
     this.calculator = calculator;
@@ -52,4 +62,26 @@ class Maps {
     }
     this.geoBounds.add([geoBounds, mostPropableHeading, rectName]);
   }
+
+  /// Emit a [MarkerRemovalEvent] so listeners can purge outdated camera markers
+  /// from their map widgets.  The actual map interaction happens wherever the
+  /// event stream is consumed; this keeps the [Maps] class free of UI details
+  /// and uses event controllers instead of legacy queues.
+  void remove_marker_from_map(double lon, double lat) {
+    _markerRemovalController.add(MarkerRemovalEvent(lon, lat));
+  }
+
+  /// Close the underlying [StreamController]. Should be called when the map is
+  /// disposed to avoid memory leaks.
+  Future<void> dispose() async {
+    await _markerRemovalController.close();
+  }
+}
+
+/// Event object describing a map marker that should be removed.
+class MarkerRemovalEvent {
+  final double lon;
+  final double lat;
+
+  MarkerRemovalEvent(this.lon, this.lat);
 }


### PR DESCRIPTION
## Summary
- restore `Maps` implementation and emit marker removals via event controller instead of queues

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dccf2de58832caca5a7557e34dc34