### PR TITLE
feat: count camera types and map markers

### DIFF
--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -1334,7 +1334,9 @@ class SpeedCamWarner {
       } else if (camAttributes[0] == 'mobile' && calculator.mobile_cams > 0) {
         calculator.mobile_cams -= 1;
       }
-      calculator.updateInfoPage('');
+      calculator.updateInfoPage(
+        'SPEED_CAMERAS:${calculator.fix_cams},${calculator.traffic_cams},${calculator.distance_cams},${calculator.mobile_cams}',
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- classify speed camera types using the `speed_camera` tag and track mobile cameras separately
- update tests to feed proper `speed_camera` tags and verify counts and markers

## Testing
- `/tmp/dart-sdk/dart-sdk/bin/dart test` *(fails: Flutter SDK is not available)*

------
https://chatgpt.com/codex/tasks/task_e_689de3c54dfc832cbb0ffb0496e0ea09