### PR TITLE
Expand status widgets across dashboard

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -248,11 +248,10 @@ class _DashboardPageState extends State<DashboardPage> {
 
   Widget _buildStatusRow() {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _buildGpsWidget(),
+        Expanded(child: _buildGpsWidget()),
         const SizedBox(width: 16),
-        _buildInternetWidget(),
+        Expanded(child: _buildInternetWidget()),
       ],
     );
   }
@@ -284,8 +283,10 @@ class _DashboardPageState extends State<DashboardPage> {
         color: color,
         borderRadius: BorderRadius.circular(12),
       ),
+      alignment: Alignment.center,
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
           Icon(icon, color: Colors.white),
           const SizedBox(width: 4),


### PR DESCRIPTION
## Summary
- have GPS and internet status tiles stretch across the dashboard for consistent width
- center contents within each tile

## Testing
- `dart format lib/ui/dashboard.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de9a94a44832c9e9fce72060a41a8