### PR TITLE
Tighten Android location update interval

### DIFF
--- a/lib/location_manager.dart
+++ b/lib/location_manager.dart
@@ -88,10 +88,15 @@ class LocationManager extends Logger {
         throw Exception('Location permissions are permanently denied');
       }
 
+      // Configure platform specific settings so we can control the minimum
+      // interval between location updates. Without specifying the interval the
+      // Android implementation defaults to 5000ms which results in location
+      // updates arriving less frequently than desired.
       positionStreamLocal = Geolocator.getPositionStream(
-        locationSettings: LocationSettings(
+        locationSettings: AndroidSettings(
           accuracy: LocationAccuracy.best,
           distanceFilter: minDistance.round(),
+          intervalDuration: Duration(milliseconds: minTime),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- ensure Android location stream uses custom interval instead of 5s default

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee1d41878832c892696ae5cca6b87