### PR TITLE
Broadcast bearing and direction updates to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a Flutter-based Android application that predicts the nearest speed came
 - Predicts the nearest speed camera coordinates.
 - Uses machine learning models for accurate predictions.
 - User-friendly interface built with Flutter.
+- Real-time dashboard displays current direction and average bearing.
 
 ## Getting Started
 1. Install Flutter: [Flutter Installation Guide](https://docs.flutter.dev/get-started/install).

--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -126,6 +126,15 @@ class SpeedCamWarner {
     logger.printLogLine('SpeedCamWarner terminating');
   }
 
+  /// Receive a raw position update from the GPS thread.  This mirrors the
+  /// ``ccp`` updates produced by the original Python implementation.
+  void updatePosition(VectorData vector) {
+    longitude = vector.longitude;
+    latitude = vector.latitude;
+    ccpBearing = vector.bearing;
+    _lastPosition = LatLng(vector.latitude, vector.longitude);
+  }
+
   void process(Timestamped<Map<String, dynamic>> envelope) {
     logger.printLogLine('Processing speedcam event');
     if (DateTime.now().difference(envelope.timestamp) > _staleThreshold) {

--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -17,7 +17,14 @@ import '../rectangle_calculator.dart';
 class DashboardPage extends StatefulWidget {
   final RectangleCalculatorThread? calculator;
   final ValueNotifier<String>? arStatus;
-  const DashboardPage({super.key, this.calculator, this.arStatus});
+  final ValueNotifier<String>? direction;
+  final ValueNotifier<String>? averageBearing;
+  const DashboardPage(
+      {super.key,
+      this.calculator,
+      this.arStatus,
+      this.direction,
+      this.averageBearing});
 
   @override
   State<DashboardPage> createState() => _DashboardPageState();
@@ -43,6 +50,10 @@ class _DashboardPageState extends State<DashboardPage> {
   ValueNotifier<String>? _arNotifier;
   double _acceleration = 0.0;
   double? _lastSpeed;
+  String _direction = '-';
+  String _averageBearing = '---.-°';
+  ValueNotifier<String>? _directionNotifier;
+  ValueNotifier<String>? _averageBearingNotifier;
 
   @override
   void initState() {
@@ -75,6 +86,17 @@ class _DashboardPageState extends State<DashboardPage> {
     if (_arNotifier != null) {
       _arStatus = _arNotifier!.value;
       _arNotifier!.addListener(_updateArStatus);
+    }
+
+    _directionNotifier = widget.direction;
+    if (_directionNotifier != null) {
+      _direction = _directionNotifier!.value;
+      _directionNotifier!.addListener(_updateDirectionBearing);
+    }
+    _averageBearingNotifier = widget.averageBearing;
+    if (_averageBearingNotifier != null) {
+      _averageBearing = _averageBearingNotifier!.value;
+      _averageBearingNotifier!.addListener(_updateDirectionBearing);
     }
   }
 
@@ -113,6 +135,14 @@ class _DashboardPageState extends State<DashboardPage> {
     });
   }
 
+  void _updateDirectionBearing() {
+    setState(() {
+      _direction = _directionNotifier?.value ?? _direction;
+      _averageBearing =
+          _averageBearingNotifier?.value ?? _averageBearing;
+    });
+  }
+
   @override
   void dispose() {
     if (_calculator != null) {
@@ -130,6 +160,8 @@ class _DashboardPageState extends State<DashboardPage> {
       _cameraSub?.cancel();
     }
     _arNotifier?.removeListener(_updateArStatus);
+    _directionNotifier?.removeListener(_updateDirectionBearing);
+    _averageBearingNotifier?.removeListener(_updateDirectionBearing);
     super.dispose();
   }
 
@@ -172,6 +204,8 @@ class _DashboardPageState extends State<DashboardPage> {
             ),
             const SizedBox(height: 16),
             _buildStatusRow(),
+            const SizedBox(height: 16),
+            _buildDirectionBearingRow(),
             if (_arStatus.isNotEmpty) ...[
               const SizedBox(height: 16),
               Text('AR: $_arStatus',
@@ -252,6 +286,28 @@ class _DashboardPageState extends State<DashboardPage> {
         Expanded(child: _buildGpsWidget()),
         const SizedBox(width: 16),
         Expanded(child: _buildInternetWidget()),
+      ],
+    );
+  }
+
+  Widget _buildDirectionBearingRow() {
+    return Row(
+      children: [
+        Expanded(
+          child: _statusTile(
+            icon: Icons.explore,
+            text: _direction,
+            color: Colors.blueGrey,
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: _statusTile(
+            icon: Icons.navigation,
+            text: _averageBearing,
+            color: Colors.blueGrey,
+          ),
+        ),
       ],
     );
   }

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -36,6 +36,8 @@ class _HomePageState extends State<HomePage> {
       DashboardPage(
         calculator: widget.controller.calculator,
         arStatus: widget.controller.arStatusNotifier,
+        direction: widget.controller.directionNotifier,
+        averageBearing: widget.controller.averageBearingValue,
       ),
       MapPage(calculator: widget.controller.calculator),
       ArPage(


### PR DESCRIPTION
## Summary
- compute driving direction and publish bearing sets in `GpsThread`
- forward direction, bearing and position updates through `AppController` and expose notifiers
- show current direction and average bearing on the dashboard
- feed position updates to `SpeedCamWarner`
- document dashboard capabilities

## Testing
- `dart format README.md lib/gps_thread.dart lib/app_controller.dart lib/ui/home.dart lib/ui/dashboard.dart lib/speed_cam_warner.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ee6649e60832cbd0b5355819269ce