### PR TITLE
Add 1000m voice prompts and configurable Dialogflow source

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -80,7 +80,7 @@
     "querystring_construction_areas2": "relation[\"highway\"=\"construction\"]"
   },
   "accusticWarner": {
-    "ai_voice_prompts": true
+    "voice_prompt_source": "dialogflow"
   },
   "gpsConsumer": {
     "display_miles": false

--- a/lib/gps_thread.dart
+++ b/lib/gps_thread.dart
@@ -55,6 +55,10 @@ class GpsThread extends Logger {
     _running = true;
     printLogLine(
         'GPS thread started testData=$gpsTestData maxEntries=$maxGpsEntries recording=$recording threshold=$gpsTreshold');
+    if (voicePromptEvents != null && _lastSignal != 'GPS_ON') {
+      voicePromptEvents!.emit('GPS_ON');
+      _lastSignal = 'GPS_ON';
+    }
     _sourceSub = source?.listen((event) {
       if (_running) {
         printLogLine(
@@ -83,6 +87,7 @@ class GpsThread extends Logger {
       voicePromptEvents!.emit('GPS_OFF');
       _lastSignal = 'GPS_OFF';
     }
+    voicePromptEvents?.emit('EXIT_APPLICATION');
   }
 
   /// Permanently dispose the underlying stream controller.

--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -930,6 +930,86 @@ class SpeedCamWarner {
           itemQueue[camCoordinates]?[1] = 'to_be_stored';
         }
       }
+      lastDistance = 500;
+    } else if (distance > 500 && distance <= 1000) {
+      camInProgress = true;
+      itemQueue[camCoordinates]?[1] = false;
+      if (lastDistance == -1 || lastDistance > 1000) {
+        if (speedcam == 'fix') {
+          voicePromptEvents.emit('FIX_1000');
+        } else if (speedcam == 'traffic') {
+          voicePromptEvents.emit('TRAFFIC_1000');
+        } else if (speedcam == 'mobile') {
+          if (!predictive) {
+            voicePromptEvents.emit('MOBILE_1000');
+          } else {
+            voicePromptEvents.emit('MOBILE_PREDICTIVE_1000');
+          }
+        } else {
+          voicePromptEvents.emit('DISTANCE_1000');
+        }
+
+        checkRoadName(linkedList, tree, camCoordinates);
+        if (resume?.isResumed() ?? true) {
+          updateSpeedcam(speedcam);
+          updateBarWidget100m(color: 2);
+          updateBarWidget300m(color: 2);
+          updateBarWidget500m(color: 2);
+          updateBarWidget1000m();
+          updateBarWidgetMeters(distance);
+          updateCamText(distance: distance.toInt());
+        }
+        if (itemQueue.containsKey(camCoordinates)) {
+          try {
+            updateCamRoad(road: itemQueue[camCoordinates]?[7]);
+            updateMaxSpeed(maxSpeed: maxSpeed);
+          } catch (_) {
+            updateCamRoad(road: '');
+            updateMaxSpeed(reset: true);
+          }
+        }
+      } else {
+        if (lastDistance == 1000) {
+          checkRoadName(linkedList, tree, camCoordinates);
+          if (resume?.isResumed() ?? true) {
+            updateSpeedcam(speedcam);
+            updateBarWidget100m(color: 2);
+            updateBarWidget300m(color: 2);
+            updateBarWidget500m(color: 2);
+            updateBarWidget1000m();
+            updateBarWidgetMeters(distance);
+            updateCamText(distance: distance.toInt());
+          }
+          if (itemQueue.containsKey(camCoordinates)) {
+            try {
+              updateCamRoad(road: itemQueue[camCoordinates]?[7]);
+              updateMaxSpeed(maxSpeed: maxSpeed);
+            } catch (_) {
+              updateCamRoad(road: '');
+              updateMaxSpeed(reset: true);
+            }
+          }
+        } else {
+          camInProgress = false;
+          triggerFreeFlow();
+          if (!processNextCam) {
+            updateCamRoad(reset: true);
+          } else {
+            if (nextCamDistanceAsInt <= maxDistanceToFutureCamera) {
+              updateCamRoad(
+                road: '$nextCamDistance\n$nextCamRoad',
+                color: [1, .9, 0, 2],
+                sizeHint: [1.0, 0.4],
+                size: '26sp',
+              );
+            } else {
+              updateCamRoad(reset: true);
+            }
+          }
+          updateMaxSpeed(reset: true);
+          itemQueue[camCoordinates]?[1] = 'to_be_stored';
+        }
+      }
       lastDistance = 1000;
     } else if (distance > 1000 && distance <= 1500) {
       camInProgress = true;

--- a/lib/voice_prompt_thread.dart
+++ b/lib/voice_prompt_thread.dart
@@ -147,6 +147,9 @@ class VoicePromptThread {
         case 'MOBILE_100':
           sound = 'mobile_100.wav';
           break;
+        case 'MOBILE_PREDICTIVE_100':
+          sound = null;
+          break;
         case 'DISTANCE_100':
           sound = 'distance_100.wav';
           break;
@@ -158,6 +161,9 @@ class VoicePromptThread {
           break;
         case 'MOBILE_300':
           sound = 'mobile_300.wav';
+          break;
+        case 'MOBILE_PREDICTIVE_300':
+          sound = null;
           break;
         case 'DISTANCE_300':
           sound = 'distance_300.wav';
@@ -171,6 +177,9 @@ class VoicePromptThread {
         case 'MOBILE_500':
           sound = 'mobile_500.wav';
           break;
+        case 'MOBILE_PREDICTIVE_500':
+          sound = null;
+          break;
         case 'DISTANCE_500':
           sound = 'distance_500.wav';
           break;
@@ -183,6 +192,9 @@ class VoicePromptThread {
         case 'MOBILE_1000':
           sound = 'mobile_1000.wav';
           break;
+        case 'MOBILE_PREDICTIVE_1000':
+          sound = null;
+          break;
         case 'DISTANCE_1000':
           sound = 'distance_1000.wav';
           break;
@@ -194,6 +206,9 @@ class VoicePromptThread {
           break;
         case 'MOBILE_NOW':
           sound = 'mobile_now.wav';
+          break;
+        case 'MOBILE_PREDICTIVE_NOW':
+          sound = null;
           break;
         case 'DISTANCE_NOW':
           sound = 'distance_now.wav';
@@ -247,15 +262,15 @@ class VoicePromptThread {
   /// Map the incoming [voiceEntry] identifier to a sound file within
   /// ``python/sounds``.  Returns `null` if no mapping exists.
   String? mapVoiceEntryToSound(String voiceEntry) {
-    final map = <String, String>{
+    final map = <String, String?>{
       'EXIT_APPLICATION': 'app_exit.wav',
       'ADDED_POLICE': 'police_added.wav',
       'ADDING_POLICE_FAILED': 'police_failed.wav',
       'STOP_APPLICATION': 'app_stopped.wav',
-      'OSM_DATA_ERROR': 'data_error.wav',
+      'OSM_DATA_ERROR': null,
       'INTERNET_CONN_FAILED': 'inet_failed.wav',
       'HAZARD': 'hazard.wav',
-      'EMPTY_DATASET_FROM_SERVER': 'empty_data.wav',
+      'EMPTY_DATASET_FROM_SERVER': null,
       'LOW_DOWNLOAD_DATA_RATE': 'low_download_rate.wav',
       'GPS_OFF': 'gps_off.wav',
       'GPS_LOW': 'gps_weak.wav',
@@ -265,22 +280,27 @@ class VoicePromptThread {
       'FIX_100': 'fix_100.wav',
       'TRAFFIC_100': 'traffic_100.wav',
       'MOBILE_100': 'mobile_100.wav',
+      'MOBILE_PREDICTIVE_100': null,
       'DISTANCE_100': 'distance_100.wav',
       'FIX_300': 'fix_300.wav',
       'TRAFFIC_300': 'traffic_300.wav',
       'MOBILE_300': 'mobile_300.wav',
+      'MOBILE_PREDICTIVE_300': null,
       'DISTANCE_300': 'distance_300.wav',
       'FIX_500': 'fix_500.wav',
       'TRAFFIC_500': 'traffic_500.wav',
       'MOBILE_500': 'mobile_500.wav',
+      'MOBILE_PREDICTIVE_500': null,
       'DISTANCE_500': 'distance_500.wav',
       'FIX_1000': 'fix_1000.wav',
       'TRAFFIC_1000': 'traffic_1000.wav',
       'MOBILE_1000': 'mobile_1000.wav',
+      'MOBILE_PREDICTIVE_1000': null,
       'DISTANCE_1000': 'distance_1000.wav',
       'FIX_NOW': 'fix_now.wav',
       'TRAFFIC_NOW': 'traffic_now.wav',
       'MOBILE_NOW': 'mobile_now.wav',
+      'MOBILE_PREDICTIVE_NOW': null,
       'DISTANCE_NOW': 'distance_now.wav',
       'CAMERA_AHEAD': 'camera_ahead.wav',
       'WATER': 'water.wav',


### PR DESCRIPTION
## Summary
- Add 1000m distance voice prompts in `speed_cam_warner.dart`
- Fix `lastDistance` update and emit predictive mobile prompts
- Sync voice prompt-to-sound mapping with Python reference
- Allow selecting Dialogflow or static WAV prompts via `voice_prompt_source` config, defaulting to Dialogflow
- Emit HAZARD, WATER and ACCESS_CONTROL voice prompts when encountering tagged map elements
- Announce POI download success or failure and wire events into the POI reader
- Enumerate predictive mobile voice prompts and include OSM/empty data status so the voice prompt thread mirrors the Python app
- Trigger remaining voice prompts: network errors, slow downloads, route monitoring and application shutdown
- Announce GPS thread activation so GPS_ON/GPS_OFF prompts are available

## Testing
- `dart format lib/gps_thread.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `sudo apt-get update` *(proxy 403; some index files ignored)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689ef43b9a6c832cad4b43fde7113e44