### PR TITLE
Fix unmatched brace in dashboard state

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -147,6 +147,7 @@ class _DashboardPageState extends State<DashboardPage> {
         : 'Camera not added: ${status ?? 'unknown error'}';
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text(msg)));
+  }
 
   void _updateDirectionBearing() {
     setState(() {
@@ -154,7 +155,6 @@ class _DashboardPageState extends State<DashboardPage> {
       _averageBearing =
           _averageBearingNotifier?.value ?? _averageBearing;
     });
-
   }
 
   @override


### PR DESCRIPTION
## Summary
- close `_addCamera` method and restore `_updateDirectionBearing` as a separate method
- ensures `_SpeedChartPainter` is top-level and resolves numerous class/member errors

## Testing
- `dart format lib/ui/dashboard.dart` *(fails: command not found)*
- `dart analyze lib/ui/dashboard.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689f08734328832ca1474265554bc80e