### PR TITLE
feat: record and replay routes

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -280,6 +280,22 @@ class AppController {
     voicePromptEvents.emit('NO_ROUTE');
   }
 
+  /// Begin recording GPS samples to a GPX file.
+  void startRecording() {
+    gps.startRecording();
+  }
+
+  /// Stop recording and persist the collected route data.
+  Future<void> stopRecording() => gps.stopRecording();
+
+  /// Replay a previously recorded route from [path].
+  Future<void> loadRoute([String path = 'gpx/route_data.gpx']) async {
+    await locationManager.stop();
+    await gps.stop();
+    await locationManager.start(gpxFile: path);
+    gps.start(source: locationManager.stream);
+  }
+
   /// Start the [DeviationCheckerThread] if it isn't already running.
   void startDeviationCheckerThread() {
     if (_deviationRunning) return;

--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'dart:ui' as ui;
 import 'dart:math' as math;
 
+import '../app_controller.dart';
 import '../rectangle_calculator.dart';
 
 /// A simple dashboard showing current speed, road name and speed camera
@@ -15,12 +16,14 @@ import '../rectangle_calculator.dart';
 /// GPS and speed‑camera updates from the background logic are reflected on the
 /// screen.
 class DashboardPage extends StatefulWidget {
+  final AppController? controller;
   final RectangleCalculatorThread? calculator;
   final ValueNotifier<String>? arStatus;
   final ValueNotifier<String>? direction;
   final ValueNotifier<String>? averageBearing;
   const DashboardPage(
       {super.key,
+      this.controller,
       this.calculator,
       this.arStatus,
       this.direction,
@@ -46,6 +49,7 @@ class _DashboardPageState extends State<DashboardPage> {
   SpeedCameraEvent? _activeCamera;
   StreamSubscription<SpeedCameraEvent>? _cameraSub;
   RectangleCalculatorThread? _calculator;
+  AppController? _controller;
   String _arStatus = '';
   ValueNotifier<String>? _arNotifier;
   double _acceleration = 0.0;
@@ -59,6 +63,7 @@ class _DashboardPageState extends State<DashboardPage> {
   void initState() {
     super.initState();
     _calculator = widget.calculator;
+    _controller = widget.controller;
     if (_calculator != null) {
       _speed = _calculator!.currentSpeedNotifier.value;
       _roadName = _calculator!.roadNameNotifier.value;
@@ -147,6 +152,27 @@ class _DashboardPageState extends State<DashboardPage> {
         : 'Camera not added: ${status ?? 'unknown error'}';
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  void _startRecording() {
+    _controller?.startRecording();
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Recording started')));
+  }
+
+  Future<void> _stopRecording() async {
+    await _controller?.stopRecording();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Recording stopped')));
+  }
+
+  Future<void> _loadRoute() async {
+    await _controller?.loadRoute();
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Route loaded')));
+  }
 
   void _updateDirectionBearing() {
     setState(() {
@@ -229,10 +255,34 @@ class _DashboardPageState extends State<DashboardPage> {
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _addCamera,
-        tooltip: 'Add police camera',
-        child: const Icon(Icons.camera_alt),
+      floatingActionButton: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          FloatingActionButton(
+            onPressed: _addCamera,
+            tooltip: 'Add police camera',
+            child: const Icon(Icons.camera_alt),
+          ),
+          const SizedBox(height: 8),
+          FloatingActionButton(
+            onPressed: _startRecording,
+            tooltip: 'Start recording',
+            child: const Icon(Icons.fiber_manual_record),
+          ),
+          const SizedBox(height: 8),
+          FloatingActionButton(
+            onPressed: _stopRecording,
+            tooltip: 'Stop recording',
+            child: const Icon(Icons.stop),
+          ),
+          const SizedBox(height: 8),
+          FloatingActionButton(
+            onPressed: _loadRoute,
+            tooltip: 'Load route',
+            child: const Icon(Icons.play_arrow),
+          ),
+        ],
       ),
     );
   }

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -34,6 +34,7 @@ class _HomePageState extends State<HomePage> {
         onFinished: _showMain,
       ),
       DashboardPage(
+        controller: widget.controller,
         calculator: widget.controller.calculator,
         arStatus: widget.controller.arStatusNotifier,
         direction: widget.controller.directionNotifier,

--- a/test/gps_thread_test.dart
+++ b/test/gps_thread_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:workspace/gps_thread.dart';
@@ -63,6 +64,23 @@ void main() {
     final second = await events.stream.first.timeout(const Duration(milliseconds: 100));
     expect(second, 'GPS_LOW');
 
+    await gps.stop();
+  });
+
+  test('gps thread records route to gpx', () async {
+    final gps = GpsThread();
+    gps.start();
+    gps.startRecording();
+    gps.addSample(VectorData(
+        longitude: 1.0,
+        latitude: 1.0,
+        speed: 50,
+        bearing: 0,
+        direction: 'Main',
+        gpsStatus: 1,
+        accuracy: 5));
+    await gps.stopRecording('gpx/test_route.gpx');
+    expect(File('gpx/test_route.gpx').existsSync(), isTrue);
     await gps.stop();
   });
 }


### PR DESCRIPTION
## Summary
- allow GPS thread to record route data to GPX and replay later
- expose recording controls via `AppController`
- add dashboard buttons to start/stop recording and load recorded route
- cover recording logic with unit test

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f090c960c832cbc3c86eab5b3190b