### PR TITLE
Make speed history widget transparent

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -543,7 +543,7 @@ class _DashboardPageState extends State<DashboardPage> {
       },
       child: Container(
         decoration: BoxDecoration(
-          color: Colors.white.withOpacity(0.05),
+          color: Colors.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
         padding: const EdgeInsets.all(12),


### PR DESCRIPTION
## Summary
- make speed history overlay fully transparent so map controls aren't obscured

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f12823fc4832cab496acd86fa61d8