### PR TITLE
Share speed cam event controller

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -29,7 +29,6 @@ class AppController {
   AppController()
       : voicePromptEvents = VoicePromptEvents(),
         locationManager = LocationManager() {
-    gps = GpsThread(voicePromptEvents: voicePromptEvents);
     overspeedChecker = OverspeedChecker();
     overspeedThread = overspeed.OverspeedThread(
       cond: overspeed.ThreadCondition(),
@@ -44,15 +43,18 @@ class AppController {
       overspeedChecker: overspeedChecker,
       overspeedThread: overspeedThread,
     );
+    gps = GpsThread(
+      voicePromptEvents: voicePromptEvents,
+      speedCamEventController: calculator.speedCamEventController,
+    );
     // Pipe GPS samples into the calculator and GPS producer and expose
     // direction updates to the UI and other threads. Position updates are
-    // forwarded to the speed camera warner so it can react to every GPS
-    // sample.
+    // forwarded to the shared speed camera event controller so the
+    // speed cam warner can react to every GPS sample.
     gps.stream.listen((vector) {
       calculator.addVectorSample(vector);
       gpsProducer.update(vector);
       directionNotifier.value = vector.direction;
-      camWarner.updatePosition(vector);
     });
 
     // Forward bearing sets to the deviation checker.

--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -667,6 +667,11 @@ class RectangleCalculatorThread {
   Stream<Timestamped<Map<String, dynamic>>> get speedCamEvents =>
       _speedCamEventController.stream;
 
+  /// Exposes the shared controller so other threads can publish position
+  /// updates and camera notifications through the same channel.
+  StreamController<Timestamped<Map<String, dynamic>>> get speedCamEventController =>
+      _speedCamEventController;
+
   /// Stream of construction areas discovered during look‑ahead queries.
   Stream<GeoRect> get constructions => _constructionStreamController.stream;
 


### PR DESCRIPTION
## Summary
- Expose rectangle calculator's speed camera event controller
- Publish GPS position updates through the shared controller so speed cam warner receives them
- Wire GPS thread to use the shared controller and drop direct position updates

## Testing
- `dart format lib/gps_thread.dart lib/rectangle_calculator.dart lib/app_controller.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f163ae440832cbcc9f30540f9f098