### PR TITLE
Expose speed cam event controller

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -673,6 +673,11 @@ class RectangleCalculatorThread {
   Stream<Timestamped<Map<String, dynamic>>> get speedCamEvents =>
       _speedCamEventController.stream;
 
+  /// Controller backing [speedCamEvents]. Exposed so that other components,
+  /// such as [GpsThread], can publish updates into the shared stream.
+  StreamController<Timestamped<Map<String, dynamic>>> get speedCamEventController =>
+      _speedCamEventController;
+
   /// Stream of construction areas discovered during look‑ahead queries.
   Stream<GeoRect> get constructions => _constructionStreamController.stream;
 


### PR DESCRIPTION
## Summary
- Expose the speed camera event controller from `RectangleCalculatorThread` for use by other components

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f33ff43c4832c8d29ccfb2f530a1a