### PR TITLE
Fix freeflow dashboard glitch

### DIFF
--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -690,12 +690,9 @@ class SpeedCamWarner {
   void triggerFreeFlow() {
     if (resume?.isResumed() ?? true) {
       updateSpeedcam('FREEFLOW');
-      updateBarWidget1000m(color: 2);
-      updateBarWidget500m(color: 2);
-      updateBarWidget300m(color: 2);
-      updateBarWidget100m(color: 2);
       updateBarWidgetMeters('');
       updateCamText(reset: true);
+      updateCamRoad(reset: true);
     }
   }
 

--- a/test/speed_cam_warner_test.dart
+++ b/test/speed_cam_warner_test.dart
@@ -1,3 +1,34 @@
+import 'package:test/test.dart';
+import 'package:workspace/speed_cam_warner.dart';
+import 'package:workspace/rectangle_calculator.dart';
+import 'package:workspace/voice_prompt_events.dart';
+import 'package:workspace/config.dart';
 
-void main() {}
+class _ResumeStub {
+  bool isResumed() => true;
+}
 
+void main() {
+  test('triggerFreeFlow clears speed camera data', () async {
+    AppConfig.loadFromMap({});
+    final calculator = RectangleCalculatorThread();
+    final warner = SpeedCamWarner(
+      resume: _ResumeStub(),
+      voicePromptEvents: VoicePromptEvents(),
+      osmWrapper: null,
+      calculator: calculator,
+    );
+
+    calculator.updateSpeedCam('CAMERA_AHEAD');
+    calculator.updateSpeedCamDistance(42);
+    calculator.updateCameraRoad('Test Road');
+
+    warner.triggerFreeFlow();
+
+    expect(calculator.speedCamNotifier.value, 'FREEFLOW');
+    expect(calculator.speedCamDistanceNotifier.value, isNull);
+    expect(calculator.cameraRoadNotifier.value, isNull);
+
+    await calculator.dispose();
+  });
+}


### PR DESCRIPTION
## Summary
- avoid overriding FREEFLOW dashboard state
- clear camera info when freeflow is triggered
- add regression test for freeflow clearing logic

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689f391419b8832c92dca310dfc027f5