### PR TITLE
feat: clear rectangle stream before emitting new bounds

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -27,7 +27,7 @@ class _MapPageState extends State<MapPage> {
   final PopupController _popupController = PopupController();
   final MapController _mapController = MapController();
   StreamSubscription<SpeedCameraEvent>? _camSub;
-  StreamSubscription<GeoRect>? _rectSub;
+  StreamSubscription<GeoRect?>? _rectSub;
   StreamSubscription<GeoRect>? _constructionSub;
   final List<Polygon> _rectPolygons = [];
 
@@ -103,7 +103,13 @@ class _MapPageState extends State<MapPage> {
     });
   }
 
-  void _onRect(GeoRect rect) {
+  void _onRect(GeoRect? rect) {
+    if (rect == null) {
+      setState(() {
+        _rectPolygons.clear();
+      });
+      return;
+    }
     final points = [
       LatLng(rect.minLat, rect.minLon),
       LatLng(rect.minLat, rect.maxLon),

--- a/test/gps_thread_test.dart
+++ b/test/gps_thread_test.dart
@@ -12,24 +12,26 @@ void main() {
     final calc = RectangleCalculatorThread();
     final completer = Completer<GeoRect>();
     calc.rectangles.listen((rect) {
-      if (!completer.isCompleted) {
+      if (rect != null && !completer.isCompleted) {
         completer.complete(rect);
       }
     });
 
     calc.bindVectorStream(gps.stream);
     gps.start();
-    gps.addSample(VectorData(
+    gps.addSample(
+      VectorData(
         longitude: 1.0,
         latitude: 1.0,
         speed: 50,
         bearing: 0,
         direction: 'Main',
         gpsStatus: 1,
-        accuracy: 5));
+        accuracy: 5,
+      ),
+    );
 
-    final rect =
-        await completer.future.timeout(const Duration(seconds: 1));
+    final rect = await completer.future.timeout(const Duration(seconds: 1));
     expect(rect, isNotNull);
     final tiles = calc.longlat2tile(1.0, 1.0, calc.zoom);
     expect(calc.lastRect!.pointInRect(tiles[0], tiles[1]), isTrue);
@@ -42,26 +44,36 @@ void main() {
     final events = VoicePromptEvents();
     final gps = GpsThread(voicePromptEvents: events, accuracyThreshold: 10);
     gps.start();
-    gps.addSample(VectorData(
+    gps.addSample(
+      VectorData(
         longitude: 1.0,
         latitude: 1.0,
         speed: 0,
         bearing: 0,
         direction: 'Main',
         gpsStatus: 1,
-        accuracy: 5));
-    final first = await events.stream.first.timeout(const Duration(milliseconds: 100));
+        accuracy: 5,
+      ),
+    );
+    final first = await events.stream.first.timeout(
+      const Duration(milliseconds: 100),
+    );
     expect(first, 'GPS_ON');
 
-    gps.addSample(VectorData(
+    gps.addSample(
+      VectorData(
         longitude: 1.0,
         latitude: 1.0,
         speed: 0,
         bearing: 0,
         direction: 'Main',
         gpsStatus: 1,
-        accuracy: 20));
-    final second = await events.stream.first.timeout(const Duration(milliseconds: 100));
+        accuracy: 20,
+      ),
+    );
+    final second = await events.stream.first.timeout(
+      const Duration(milliseconds: 100),
+    );
     expect(second, 'GPS_LOW');
 
     await gps.stop();
@@ -71,14 +83,17 @@ void main() {
     final gps = GpsThread();
     gps.start();
     gps.startRecording();
-    gps.addSample(VectorData(
+    gps.addSample(
+      VectorData(
         longitude: 1.0,
         latitude: 1.0,
         speed: 50,
         bearing: 0,
         direction: 'Main',
         gpsStatus: 1,
-        accuracy: 5));
+        accuracy: 5,
+      ),
+    );
     await gps.stopRecording('gpx/test_route.gpx');
     expect(File('gpx/test_route.gpx').existsSync(), isTrue);
     await gps.stop();


### PR DESCRIPTION
## Summary
- allow rectangle stream to emit null and flush previous rectangles before broadcasting new bounds
- clear polygons on the map when a null rectangle arrives
- update tests to ignore null stream events

## Testing
- `dart test` *(fails: Because workspace depends on flutter_test from sdk which doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c265c80832cbc2a06220d9fecc0