### PR TITLE
Fix overspeed queue blocking and add overspeed indicator widget

### DIFF
--- a/lib/overspeed_thread.dart
+++ b/lib/overspeed_thread.dart
@@ -122,8 +122,8 @@ class OverspeedThread extends Logger {
   }
 
   Future<Map<String, dynamic>> _consumeOverspeedEntry() async {
-    while (_overspeedQueue.isEmpty) {
-      await _overspeedNotifier.stream.first;
+    if (_overspeedQueue.isEmpty) {
+      return {};
     }
     return _overspeedQueue.removeFirst();
   }

--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 
 import '../app_controller.dart';
 import '../rectangle_calculator.dart';
+import 'overspeed_indicator.dart';
 
 /// A simple dashboard showing current speed, road name and speed camera
 /// information.
@@ -545,8 +546,7 @@ class _DashboardPageState extends State<DashboardPage> {
                 _buildMaxSpeedWidget(),
               ],
               if (_overspeedDiff != null)
-                Text('Slow down by ${_overspeedDiff!} km/h',
-                    style: const TextStyle(color: Colors.redAccent)),
+                OverspeedIndicator(diff: _overspeedDiff!),
             ],
           ),
         ],

--- a/lib/ui/overspeed_indicator.dart
+++ b/lib/ui/overspeed_indicator.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+/// Displays the current overspeed difference inside a red circular badge.
+class OverspeedIndicator extends StatelessWidget {
+  final int diff;
+  const OverspeedIndicator({super.key, required this.diff});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: const BoxDecoration(
+        color: Colors.redAccent,
+        shape: BoxShape.circle,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '+$diff',
+            style: const TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.bold),
+          ),
+          const Text(
+            'km/h',
+            style: TextStyle(color: Colors.white, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/overspeed_thread_test.dart
+++ b/test/overspeed_thread_test.dart
@@ -31,8 +31,9 @@ void main() {
     await thread.process();
     expect(layout.lastValue, 10);
 
+    // Now update only the speed without providing a new overspeed entry.
+    // The thread should reuse the last max speed and reset the warning.
     thread.addCurrentSpeed(40);
-    thread.addOverspeedEntry({});
     await thread.process();
     expect(layout.lastValue, isNull);
     expect(layout.resetCount, 1);


### PR DESCRIPTION
## Summary
- prevent overspeed thread from blocking when no max-speed entry is queued
- add a circular `OverspeedIndicator` widget and integrate it into the dashboard
- extend overspeed thread test for missing entries

## Testing
- `dart format lib/overspeed_thread.dart lib/ui/overspeed_indicator.dart lib/ui/dashboard.dart test/overspeed_thread_test.dart` *(failed: command not found)*
- `dart test` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a061153840832ca917c5ef130b52fc