### PR TITLE
Handle async Dialogflow client in voice prompt thread

### DIFF
--- a/test/voice_prompt_thread_test.dart
+++ b/test/voice_prompt_thread_test.dart
@@ -2,6 +2,7 @@ import 'package:test/test.dart';
 
 import '../lib/voice_prompt_events.dart';
 import '../lib/voice_prompt_thread.dart';
+import '../lib/dialogflow_client.dart';
 
 class FakeTts {
   String? lastText;
@@ -13,7 +14,8 @@ class FakeTts {
   }
 }
 
-class FakeDialogflow {
+class FakeDialogflow implements DialogflowService {
+  @override
   Future<String> detectIntent(String text) async => 'response:$text';
 }
 


### PR DESCRIPTION
## Summary
- await Dialogflow client before usage in `VoicePromptThread`
- update tests to use `DialogflowService` interface

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2043c9230832cbc8ba46d8a38cf3a