### PR TITLE
Fix speed history layout and move add camera button to app bar

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -251,9 +251,17 @@ class _DashboardPageState extends State<DashboardPage> {
 
   @override
   Widget build(BuildContext context) {
+    const double cameraInfoHeight = 120;
     return Scaffold(
       appBar: AppBar(
         title: const Text('SpeedCamWarner'),
+        actions: [
+          IconButton(
+            onPressed: _addCamera,
+            tooltip: 'Add police camera',
+            icon: const Icon(Icons.camera_alt),
+          ),
+        ],
       ),
       body: Container(
         decoration: const BoxDecoration(
@@ -267,7 +275,13 @@ class _DashboardPageState extends State<DashboardPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _buildCameraInfo(),
+            SizedBox(
+              height: cameraInfoHeight,
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: _buildCameraInfo(),
+              ),
+            ),
             const SizedBox(height: 16),
             Expanded(
               child: Row(
@@ -303,12 +317,6 @@ class _DashboardPageState extends State<DashboardPage> {
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          FloatingActionButton(
-            onPressed: _addCamera,
-            tooltip: 'Add police camera',
-            child: const Icon(Icons.camera_alt),
-          ),
-          const SizedBox(height: 8),
           FloatingActionButton(
             onPressed: _startRecording,
             tooltip: 'Start recording',


### PR DESCRIPTION
## Summary
- reserve fixed space for camera info to prevent speed widget resizing
- move police add button to top right app bar to avoid overlaying speed history
- remove add button from floating action area

## Testing
- `dart format lib/ui/dashboard.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20838bc78832c9e637b570b6bea8d