### PR TITLE
fix: avoid bottom overflow in AR camera layout

### DIFF
--- a/lib/ar_layout.dart
+++ b/lib/ar_layout.dart
@@ -449,11 +449,11 @@ class ButtonsLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     final Size size = MediaQuery.of(context).size;
     final bool isPortrait = size.width < size.height;
-
+    late final Widget layout;
     if (isPortrait) {
       final double buttonSize =
           math.min(size.width / 4, size.height * 0.2);
-      return Align(
+      layout = Align(
         alignment: Alignment.bottomCenter,
         child: SizedBox(
           width: buttonSize * 4,
@@ -484,7 +484,7 @@ class ButtonsLayout extends StatelessWidget {
     } else {
       final double buttonSize =
           math.min(size.width * 0.2, size.height / 4);
-      return Align(
+      layout = Align(
         alignment: Alignment.centerRight,
         child: SizedBox(
           width: buttonSize,
@@ -513,6 +513,8 @@ class ButtonsLayout extends StatelessWidget {
         ),
       );
     }
+
+    return SafeArea(child: layout);
   }
 
   Widget _button(


### PR DESCRIPTION
## Summary
- wrap camera controls in SafeArea to prevent bottom overflow in AR view

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b233aa8832cbb5732c69b5d7987