### PR TITLE
Fix camera widget overflow

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -234,7 +234,8 @@ class _DashboardPageState extends State<DashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    const double cameraInfoHeight = 120;
+    final hasCameraInfo = _speedCamWarning != null || _activeCamera != null;
+    final topPadding = hasCameraInfo ? 152.0 : 16.0;
     return Scaffold(
       appBar: AppBar(
         title: const Text('SpeedCamWarner'),
@@ -246,56 +247,63 @@ class _DashboardPageState extends State<DashboardPage> {
           ),
         ],
       ),
-      body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF1E1E1E), Color(0xFF121212)],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
+      body: Stack(
+        children: [
+          Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                colors: [Color(0xFF1E1E1E), Color(0xFF121212)],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+            ),
+            padding: EdgeInsets.fromLTRB(16, topPadding, 16, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(child: _buildRoadNameWidget()),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: Row(
+                    children: [
+                      Expanded(flex: 2, child: _buildSpeedWidget()),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          children: [
+                            Expanded(child: _buildAccelerationWidget()),
+                            const SizedBox(height: 16),
+                            Expanded(child: _buildSpeedHistoryWidget()),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _buildStatusRow(),
+                const SizedBox(height: 16),
+                _buildDirectionBearingRow(),
+                if (_arStatus.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  Text('AR: $_arStatus',
+                      style:
+                          const TextStyle(color: Colors.white54, fontSize: 16)),
+                ],
+              ],
+            ),
           ),
-        ),
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            SizedBox(
-              height: cameraInfoHeight,
+          if (hasCameraInfo)
+            SafeArea(
               child: Align(
                 alignment: Alignment.topCenter,
-                child: _buildCameraInfo(),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: _buildCameraInfo(),
+                ),
               ),
             ),
-            const SizedBox(height: 16),
-            Center(child: _buildRoadNameWidget()),
-            const SizedBox(height: 16),
-            Expanded(
-              child: Row(
-                children: [
-                  Expanded(flex: 2, child: _buildSpeedWidget()),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      children: [
-                        Expanded(child: _buildAccelerationWidget()),
-                        const SizedBox(height: 16),
-                        Expanded(child: _buildSpeedHistoryWidget()),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-            _buildStatusRow(),
-            const SizedBox(height: 16),
-            _buildDirectionBearingRow(),
-            if (_arStatus.isNotEmpty) ...[
-              const SizedBox(height: 16),
-              Text('AR: $_arStatus',
-                  style: const TextStyle(color: Colors.white54, fontSize: 16)),
-            ],
-          ],
-        ),
+        ],
       ),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,


### PR DESCRIPTION
## Summary
- overlay camera warning panel to prevent layout overflow
- add dynamic padding so speed and status widgets fit on screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a328bc49a0832cbf1eabd72e00ce48