### PR TITLE
Reduce construction lookup frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ file the log will show messages like `Service account file not found` and the
 app will fall back to the limited data bundled with the repository.
 
 To avoid excessive network traffic the lookahead requests are rate limited. The
-interval is controlled by the `dosAttackPreventionIntervalDownloads` variable in
-`lib/rectangle_calculator.dart` (default `30` seconds). Adjust this value if you
-need more frequent updates during development.
+interval for speed‑camera downloads is controlled by the
+`dosAttackPreventionIntervalDownloads` variable in
+`lib/rectangle_calculator.dart` (default `30` seconds). Construction area
+queries use a separate `constructionAreaLookupInterval` (default `120`
+seconds) to further reduce server load. Adjust these values if you need more
+frequent updates during development.
 
 ## Project Structure
 - `lib/`: Contains the main application code.

--- a/test/rectangle_calculator_methods_test.dart
+++ b/test/rectangle_calculator_methods_test.dart
@@ -564,6 +564,7 @@ class _RateLimitCalc extends RectangleCalculatorThread {
   _RateLimitCalc() {
     dosAttackPreventionIntervalDownloads = 1;
     constructionAreaStartupTriggerMax = 0;
+    constructionAreaLookupInterval = 1;
   }
 
   @override


### PR DESCRIPTION
## Summary
- add dedicated `constructionAreaLookupInterval` to throttle construction zone requests
- document construction lookup interval

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32879da98832ca4577cbbb19387b6