### PR TITLE
Ensure existing construction areas display on map

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -56,6 +56,12 @@ class _MapPageState extends State<MapPage> {
     _constructionSub = widget.calculator.constructions.listen(
       _onConstructionArea,
     );
+    // Populate map with already known construction areas so that opening the
+    // map after the lookup has finished still shows them.  The construction
+    // stream only emits new areas, so we need to manually add existing ones.
+    for (final area in widget.calculator.constructionAreas) {
+      _onConstructionArea(area);
+    }
   }
 
   void _updatePosition() {


### PR DESCRIPTION
## Summary
- Populate MapPage with previously fetched construction areas on init so users see them even if lookup completed earlier

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a33b1501ec832cb8d705648e1e8f28