### PR TITLE
Handle boolean voice prompt flag

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -91,10 +91,10 @@ class AppController {
     voiceThread = VoicePromptThread(
       voicePromptEvents: voicePromptEvents,
       dialogflowClient: dialogflow,
-      aiVoicePrompts:
-          (AppConfig.get<String>('accusticWarner.voice_prompt_source') ??
-                  'dialogflow') ==
-              'dialogflow',
+      aiVoicePrompts: (AppConfig.get<dynamic>(
+                    'accusticWarner.voice_prompt_source') ??
+                'dialogflow') ==
+            'dialogflow',
     );
     unawaited(voiceThread.run());
 

--- a/test/app_config_voice_prompt_source_test.dart
+++ b/test/app_config_voice_prompt_source_test.dart
@@ -1,0 +1,17 @@
+import 'package:test/test.dart';
+import '../lib/config.dart';
+
+void main() {
+  test('voice_prompt_source accepts boolean without crashing', () {
+    AppConfig.loadFromMap({
+      'accusticWarner': {'voice_prompt_source': false},
+    });
+
+    final aiVoice =
+        (AppConfig.get<dynamic>('accusticWarner.voice_prompt_source') ??
+                'dialogflow') ==
+            'dialogflow';
+
+    expect(aiVoice, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- avoid crash when `accusticWarner.voice_prompt_source` is boolean
- cover boolean flag with unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a349ccf4ac832cb91f40dbadecab7f