### PR TITLE
Gracefully handle offline service account auth

### DIFF
--- a/lib/poi_reader.dart
+++ b/lib/poi_reader.dart
@@ -374,6 +374,13 @@ class POIReader extends Logger {
     printLogLine("Updating POI's from cloud ..");
     try {
       final driveClient = await ServiceAccount.buildDriveFromCredentials();
+      if (driveClient == null) {
+        printLogLine(
+          'Updating cameras (file_id: ${ServiceAccount.fileId}) from service account failed! (NO_AUTH_CLIENT)',
+          logLevel: 'ERROR',
+        );
+        return;
+      }
       final status = await ServiceAccount.downloadFileFromGoogleDrive(
         ServiceAccount.fileId,
         driveClient,

--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -219,6 +219,9 @@ Future<(bool, String?)> uploadCameraToDrive({
   }
   try {
     final client = await ServiceAccount.buildDriveFromCredentials();
+    if (client == null) {
+      return (false, 'NO_AUTH_CLIENT');
+    }
     final res = await ServiceAccount.uploadFileToGoogleDrive(
       ServiceAccount.fileId,
       ServiceAccount.folderId,


### PR DESCRIPTION
## Summary
- avoid crashes when OAuth token fetch fails offline
- guard POI download and camera upload when auth client can't be created

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a433edb420832ca86b79c410f7565f