### PR TITLE
Fix stats page camera count discrepancy

### DIFF
--- a/lib/ui/stats_page.dart
+++ b/lib/ui/stats_page.dart
@@ -27,6 +27,7 @@ class _StatsPageState extends State<StatsPage> {
   int _predictive = 0;
   int _construction = 0;
   int _poi = 0; // Placeholder for future POI integration
+  final Set<String> _seenCameras = {};
 
   void _onConstructionCount() {
     setState(() {
@@ -43,13 +44,16 @@ class _StatsPageState extends State<StatsPage> {
     widget.calculator.constructionAreaCountNotifier
         .addListener(_onConstructionCount);
     _sub = widget.calculator.cameras.listen((cam) {
-      setState(() {
-        if (cam.fixed) _fixed++;
-        if (cam.traffic) _traffic++;
-        if (cam.distance) _distance++;
-        if (cam.mobile) _mobile++;
-        if (cam.predictive) _predictive++;
-      });
+      final key = '${cam.latitude},${cam.longitude}';
+      if (_seenCameras.add(key)) {
+        setState(() {
+          if (cam.fixed) _fixed++;
+          if (cam.traffic) _traffic++;
+          if (cam.distance) _distance++;
+          if (cam.mobile) _mobile++;
+          if (cam.predictive) _predictive++;
+        });
+      }
     });
   }
 

--- a/test/stats_page_test.dart
+++ b/test/stats_page_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:workspace/rectangle_calculator.dart';
+import 'package:workspace/overspeed_checker.dart';
+import 'package:workspace/ui/stats_page.dart';
+
+void main() {
+  testWidgets('StatsPage counts unique cameras only once', (tester) async {
+    final calc = RectangleCalculatorThread(overspeedChecker: OverspeedChecker());
+    addTearDown(() async => await calc.dispose());
+
+    await tester.pumpWidget(MaterialApp(home: StatsPage(calculator: calc)));
+
+    final cam = SpeedCameraEvent(latitude: 1.0, longitude: 1.0, fixed: true);
+    await calc.updateSpeedCams([cam]);
+    await calc.updateSpeedCams([cam]);
+
+    await tester.pumpAndSettle();
+
+    final rowFinder = find.ancestor(
+      of: find.text('Fix Cameras'),
+      matching: find.byType(Row),
+    );
+    final countFinder = find.descendant(
+      of: rowFinder,
+      matching: find.text('1'),
+    );
+    expect(countFinder, findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- avoid double-counting cameras on the statistics page
- add widget test covering camera deduplication logic

## Testing
- `flutter test test/stats_page_test.dart` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4731b3048832c94ab2a2ebbe6189c