### PR TITLE
Improve dashboard layout and overspeed indicator

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -257,16 +257,19 @@ class _DashboardPageState extends State<DashboardPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              Center(child: _buildRoadNameWidget()),
+              const SizedBox(height: 16),
               if (hasCameraInfo) ...[
                 _buildCameraInfo(),
                 const SizedBox(height: 16),
               ],
-              Center(child: _buildRoadNameWidget()),
-              const SizedBox(height: 16),
               SizedBox(
                 // Provide more vertical space so the speed and history widgets
                 // are easier to read on larger displays.
-                height: MediaQuery.of(context).size.height * 0.45,
+                height: math.min(
+                  MediaQuery.of(context).size.height * 0.5,
+                  320,
+                ),
                 child: Row(
                   children: [
                     Expanded(child: _buildSpeedWidget()),
@@ -571,11 +574,10 @@ class _DashboardPageState extends State<DashboardPage> {
                 ],
               ),
               if (_overspeedDiff != null)
-                Positioned(
-                  bottom: 16,
-                  left: 0,
-                  right: 0,
-                  child: Center(
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
                     child: OverspeedIndicator(diff: _overspeedDiff!),
                   ),
                 ),

--- a/lib/ui/overspeed_indicator.dart
+++ b/lib/ui/overspeed_indicator.dart
@@ -8,26 +8,33 @@ class OverspeedIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      width: 64,
+      height: 64,
       padding: const EdgeInsets.all(8),
       decoration: const BoxDecoration(
         color: Colors.redAccent,
         shape: BoxShape.circle,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            '+$diff',
-            style: const TextStyle(
+      alignment: Alignment.center,
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '+$diff',
+              style: const TextStyle(
                 color: Colors.white,
                 fontSize: 20,
-                fontWeight: FontWeight.bold),
-          ),
-          const Text(
-            'km/h',
-            style: TextStyle(color: Colors.white, fontSize: 12),
-          ),
-        ],
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const Text(
+              'km/h',
+              style: TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Reorder dashboard widgets and constrain the speed section height
- Align overspeed badge at the bottom of the speed gauge
- Give overspeed indicator a fixed size and scale its contents to avoid overflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a516bcf8c8832cae1fcee20283a275