### PR TITLE
Improve dashboard layout when no camera is active

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -253,45 +253,46 @@ class _DashboardPageState extends State<DashboardPage> {
           ),
         ),
         padding: const EdgeInsets.all(16),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Center(child: _buildRoadNameWidget()),
-              const SizedBox(height: 16),
-              if (hasCameraInfo) ...[
-                _buildCameraInfo(),
-                const SizedBox(height: 16),
-              ],
-              SizedBox(
-                // Provide more vertical space so the speed and history widgets
-                // are easier to read on larger displays.
-                height: math.min(
-                  MediaQuery.of(context).size.height * 0.5,
-                  320,
-                ),
-                child: Row(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Expanded(child: _buildSpeedWidget()),
-                    const SizedBox(width: 16),
+                    Center(child: _buildRoadNameWidget()),
+                    const SizedBox(height: 16),
+                    if (hasCameraInfo) ...[
+                      _buildCameraInfo(),
+                      const SizedBox(height: 16),
+                    ],
                     Expanded(
-                      child: Column(
+                      child: Row(
                         children: [
-                          Expanded(child: _buildAccelerationWidget()),
-                          const SizedBox(height: 16),
-                          Expanded(child: _buildSpeedHistoryWidget()),
+                          Expanded(child: _buildSpeedWidget()),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              children: [
+                                Expanded(child: _buildAccelerationWidget()),
+                                const SizedBox(height: 16),
+                                Expanded(child: _buildSpeedHistoryWidget()),
+                              ],
+                            ),
+                          ),
                         ],
                       ),
                     ),
+                    const SizedBox(height: 16),
+                    _buildStatusRow(),
+                    const SizedBox(height: 16),
+                    _buildDirectionBearingRow(),
                   ],
                 ),
               ),
-              const SizedBox(height: 16),
-              _buildStatusRow(),
-              const SizedBox(height: 16),
-              _buildDirectionBearingRow(),
-            ],
-          ),
+            );
+          },
         ),
       ),
       floatingActionButton: Column(


### PR DESCRIPTION
## Summary
- Expand dashboard content to use available space when no camera info is shown
- Replace fixed-height area with flexible `LayoutBuilder` + `Expanded` layout

## Testing
- `dart format lib/ui/dashboard.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51cc1f4b8832c9fc3590e980457c7