### PR TITLE
Reorder dashboard widgets

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -262,20 +262,14 @@ class _DashboardPageState extends State<DashboardPage> {
               children: [
                 Center(child: _buildRoadNameWidget()),
                 const SizedBox(height: 16),
+                Expanded(flex: 2, child: _buildSpeedWidget()),
+                const SizedBox(height: 16),
                 Expanded(
                   child: Row(
                     children: [
-                      Expanded(flex: 2, child: _buildSpeedWidget()),
+                      Expanded(child: _buildAccelerationWidget()),
                       const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
-                          children: [
-                            Expanded(child: _buildAccelerationWidget()),
-                            const SizedBox(height: 16),
-                            Expanded(child: _buildSpeedHistoryWidget()),
-                          ],
-                        ),
-                      ),
+                      Expanded(child: _buildSpeedHistoryWidget()),
                     ],
                   ),
                 ),
@@ -288,9 +282,12 @@ class _DashboardPageState extends State<DashboardPage> {
           ),
           if (hasCameraInfo)
             Positioned(
-              top: 80,
-              right: 16,
-              child: SizedBox(width: 200, child: _buildCameraInfo()),
+              top: 16,
+              left: 0,
+              right: 0,
+              child: Center(
+                child: SizedBox(width: 200, child: _buildCameraInfo()),
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Center camera info overlay at top of dashboard
- Restructure dashboard layout: road name row, speed gauge row, acceleration and speed history side by side

## Testing
- `dart format lib/ui/dashboard.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8d2c6ec832c829b66e87dde6bae