### PR TITLE
Refine dashboard widgets

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -260,9 +260,9 @@ class _DashboardPageState extends State<DashboardPage> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Center(child: _buildRoadNameWidget()),
-                const SizedBox(height: 16),
                 Expanded(flex: 2, child: _buildSpeedWidget()),
+                const SizedBox(height: 16),
+                Center(child: _buildRoadNameWidget()),
                 const SizedBox(height: 16),
                 Expanded(
                   child: Row(
@@ -285,9 +285,7 @@ class _DashboardPageState extends State<DashboardPage> {
               top: 16,
               left: 0,
               right: 0,
-              child: Center(
-                child: SizedBox(width: 200, child: _buildCameraInfo()),
-              ),
+              child: _buildCameraInfo(),
             ),
         ],
       ),
@@ -329,6 +327,7 @@ class _DashboardPageState extends State<DashboardPage> {
     }
     final colors = _cameraGradientColors();
     return Container(
+      width: double.infinity,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
         gradient: LinearGradient(
@@ -446,8 +445,7 @@ class _DashboardPageState extends State<DashboardPage> {
     required Color color,
   }) {
     return Container(
-      // Increase padding so the status tiles appear larger and easier to tap.
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       decoration: BoxDecoration(
         color: color,
         borderRadius: BorderRadius.circular(12),
@@ -456,12 +454,12 @@ class _DashboardPageState extends State<DashboardPage> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(icon, color: Colors.white, size: 32),
+          Icon(icon, color: Colors.white, size: 24),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               text,
-              style: const TextStyle(color: Colors.white, fontSize: 18),
+              style: const TextStyle(color: Colors.white, fontSize: 14),
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
             ),


### PR DESCRIPTION
## Summary
- Stretch camera info widget to full screen width
- Show road name beneath speed gauge
- Shrink status tiles for GPS, internet, AR, direction and bearing

## Testing
- `dart format lib/ui/dashboard.dart` *(failed: command not found)*
- `dart analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d6562934832cb80b1c740f9d1995