### PR TITLE
Add AR detection alert and dashboard highlight

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -394,10 +394,11 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   Widget _buildAiWidget() {
+    final Color color = _arStatus == 'HUMAN' ? Colors.red : Colors.blueGrey;
     return _statusTile(
       icon: Icons.smart_toy,
       text: 'AI: $_arStatus',
-      color: Colors.blueGrey,
+      color: color,
     );
   }
 


### PR DESCRIPTION
## Summary
- show an Android alert when AR detects a face or body and dismiss it when detection stops
- turn dashboard AI indicator red on detection and grey otherwise
- log when AR detection begins to confirm the algorithm runs
- remove placeholder service-account assets to match original repository state

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: Invalid response from proxy: HTTP/1.1 403 Forbidden)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d88a0c34832c9e5d1a8c08d6a260