### PR TITLE
Handle closed stream in deviation checker

### DIFF
--- a/lib/deviation_checker.dart
+++ b/lib/deviation_checker.dart
@@ -38,6 +38,9 @@ class DeviationCheckerThread extends Logger {
   }) : super('DeviationCheckerThread', logViewer: logViewer);
 
   void addAverageAngleData(dynamic data) {
+    if (_averageAngleController.isClosed) {
+      return;
+    }
     _averageAngleController.add(data);
   }
 


### PR DESCRIPTION
## Summary
- Prevent adding average angle data after the stream controller is closed to avoid `Bad state: Cannot add event after closing`

## Testing
- `dart format lib/deviation_checker.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e6d71dec832c93a6eeda08ab3d75