### PR TITLE
Add POI lookup with map integration and stats

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -451,6 +451,8 @@ class RectangleCalculatorThread {
   final ValueNotifier<int> constructionAreaCountNotifier = ValueNotifier<int>(
     0,
   );
+  /// Tracks the number of POIs returned by the last lookup.
+  final ValueNotifier<int> poiCountNotifier = ValueNotifier<int>(0);
   final ValueNotifier<bool> onlineStatusNotifier = ValueNotifier<bool>(false);
   final ValueNotifier<bool> gpsStatusNotifier = ValueNotifier<bool>(false);
   final ValueNotifier<String?> maxspeedStatusNotifier = ValueNotifier<String?>(
@@ -2880,6 +2882,7 @@ class RectangleCalculatorThread {
 
   void updateCamRadius(double value) => camRadiusNotifier.value = value;
   void updateInfoPage(String value) => infoPageNotifier.value = value;
+  void updatePoiCount(int value) => poiCountNotifier.value = value;
   void updateOnlineStatus(bool value) => onlineStatusNotifier.value = value;
   void updateGpsStatus(bool value) => gpsStatusNotifier.value = value;
 

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -40,7 +40,11 @@ class _HomePageState extends State<HomePage> {
         direction: widget.controller.directionNotifier,
         averageBearing: widget.controller.averageBearingValue,
       ),
-      MapPage(calculator: widget.controller.calculator),
+        MapPage(
+          calculator: widget.controller.calculator,
+          poiStream: widget.controller.poiStream,
+          onPoiLookup: widget.controller.lookupPois,
+        ),
       ArPage(
         controller: widget.controller,
         onReturn: _showMain,

--- a/lib/ui/stats_page.dart
+++ b/lib/ui/stats_page.dart
@@ -26,22 +26,30 @@ class _StatsPageState extends State<StatsPage> {
   int _mobile = 0;
   int _predictive = 0;
   int _construction = 0;
-  int _poi = 0; // Placeholder for future POI integration
+    int _poi = 0;
   final Set<String> _seenCameras = {};
 
-  void _onConstructionCount() {
-    setState(() {
-      _construction = widget.calculator.constructionAreaCountNotifier.value;
-    });
-  }
+    void _onConstructionCount() {
+      setState(() {
+        _construction = widget.calculator.constructionAreaCountNotifier.value;
+      });
+    }
+
+    void _onPoiCount() {
+      setState(() {
+        _poi = widget.calculator.poiCountNotifier.value;
+      });
+    }
 
   @override
   void initState() {
     super.initState();
-    _construction = widget.calculator.constructionAreaCountNotifier.value;
-    widget.calculator.constructionAreaCountNotifier
-        .addListener(_onConstructionCount);
-    _sub = widget.calculator.cameras.listen((cam) {
+      _construction = widget.calculator.constructionAreaCountNotifier.value;
+      _poi = widget.calculator.poiCountNotifier.value;
+      widget.calculator.constructionAreaCountNotifier
+          .addListener(_onConstructionCount);
+      widget.calculator.poiCountNotifier.addListener(_onPoiCount);
+      _sub = widget.calculator.cameras.listen((cam) {
       final key = '${cam.latitude},${cam.longitude}';
       if (_seenCameras.add(key)) {
         setState(() {
@@ -57,11 +65,12 @@ class _StatsPageState extends State<StatsPage> {
 
   @override
   void dispose() {
-    _sub.cancel();
-    widget.calculator.constructionAreaCountNotifier
-        .removeListener(_onConstructionCount);
-    super.dispose();
-  }
+      _sub.cancel();
+      widget.calculator.constructionAreaCountNotifier
+          .removeListener(_onConstructionCount);
+      widget.calculator.poiCountNotifier.removeListener(_onPoiCount);
+      super.dispose();
+    }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add stream-based POI lookup and Overpass query
- show POI count on stats page
- allow users to trigger POI search and display markers on map

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ed82c18832c908b1e2c9fdadc48