### PR TITLE
Ensure processed speed camera log is emitted

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -2184,30 +2184,30 @@ class RectangleCalculatorThread {
         logLevel: 'ERROR',
       );
       logger.printLogLine(stack.toString(), logLevel: 'DEBUG');
-    } finally {
+    }
+
+    logger.printLogLine(
+      'Processed ${cams.length} cameras from $lookupType lookup',
+    );
+    if (cams.isNotEmpty) {
       logger.printLogLine(
-        'Processed ${cams.length} cameras from $lookupType lookup',
+        'Found ${cams.length} cameras from $lookupType lookup',
       );
-      if (cams.isNotEmpty) {
+      try {
+        // Await the update so the speed cam warner sees new cameras before
+        // handling the next CCP event.
+        await updateSpeedCams(cams);
+      } catch (e, stack) {
         logger.printLogLine(
-          'Found ${cams.length} cameras from $lookupType lookup',
+          'updateSpeedCams failed: $e',
+          logLevel: 'ERROR',
         );
-        try {
-          // Await the update so the speed cam warner sees new cameras before
-          // handling the next CCP event.
-          await updateSpeedCams(cams);
-        } catch (e, stack) {
-          logger.printLogLine(
-            'updateSpeedCams failed: $e',
-            logLevel: 'ERROR',
-          );
-          logger.printLogLine(stack.toString(), logLevel: 'DEBUG');
-        }
-        updateMapQueue();
-        updateInfoPage(
-          'SPEED_CAMERAS:$fix_cams,$traffic_cams,$distance_cams,$mobile_cams',
-        );
+        logger.printLogLine(stack.toString(), logLevel: 'DEBUG');
       }
+      updateMapQueue();
+      updateInfoPage(
+        'SPEED_CAMERAS:$fix_cams,$traffic_cams,$distance_cams,$mobile_cams',
+      );
     }
 
   void resolveDangersOnTheRoad(Map<String, dynamic> way) {


### PR DESCRIPTION
## Summary
- Move summary logging for speed camera lookups outside `finally` to guarantee it always runs
- Keep camera updates and info page refresh only when cameras are found

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d2a5d48832c89fd30ec41c05ef2