### PR TITLE
Increase transparency of camera overlay

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -151,7 +151,7 @@ class _DashboardPageState extends State<DashboardPage> {
     } else {
       colors = [Colors.red, Colors.red.shade900];
     }
-    return colors.map((c) => c.withOpacity(0.9)).toList();
+    return colors.map((c) => c.withOpacity(0.5)).toList();
   }
 
   void _clearCameraInfo() {


### PR DESCRIPTION
## Summary
- Render the camera warning overlay at half opacity so the speed gauge remains legible.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0543f6ffc832c9317bf22b34b5661