### PR TITLE
Initialize predictive model before rectangle calculations start

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -195,8 +195,9 @@ class AppController {
       gpxFile: gpxFile,
       positionStream: positionStream,
     );
-    gps.start(source: locationManager.stream);
+    await calculator.init();
     calculator.run();
+    gps.start(source: locationManager.stream);
     deviationChecker.start();
     _running = true;
   }


### PR DESCRIPTION
## Summary
- Ensure RectangleCalculatorThread loads its predictive model before processing by awaiting `calculator.init()` in `AppController.start`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b06af9fd94832cbed7290936610491