### PR TITLE
Prevent predictive camera icon flicker

### DIFF
--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -728,6 +728,15 @@ class SpeedCamWarner {
     int nextCamDistanceAsInt = 0,
     bool processNextCam = false,
   }) {
+    // Predictive cameras are sometimes reported in parallel with an already
+    // active camera.  In that case we do not want to override the current
+    // warning with a generic "CAMERA_AHEAD" update as this results in the UI
+    // flickering between two icons.  Skip predictive updates while a real
+    // camera is being processed.
+    if (predictive && camInProgress) {
+      return;
+    }
+
     if (distance >= 0 && distance <= 100) {
       camInProgress = true;
       if (lastDistance == -1 || lastDistance > 100) {


### PR DESCRIPTION
## Summary
- Skip predictive camera updates when a real camera is already being processed
- Keep dashboard icon on active camera and ignore predictive updates while one is active

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81f2080e0832ca15bfdac3356369b