### PR TITLE
Parallelize speed camera lookups and async road name resolution

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -2179,14 +2179,14 @@ class RectangleCalculatorThread {
 
   Future<void> speedCamLookupAhead(GeoRect rect, {http.Client? client}) async {
     logger.printLogLine('speedCamLookupAhead bounds: $rect');
-
     final camFuture =
         triggerOsmLookup(rect, lookupType: 'camera_ahead', client: client);
     final distFuture =
         triggerOsmLookup(rect, lookupType: 'distance_cam', client: client);
 
-    final camRes = await camFuture;
-    final distRes = await distFuture;
+    final results = await Future.wait([camFuture, distFuture]);
+    final camRes = results[0];
+    final distRes = results[1];
 
     logger.printLogLine(
       'speedCamLookupAhead result for camera_ahead success=${camRes.success} elements=${camRes.elements?.length ?? 0}',
@@ -2279,13 +2279,18 @@ class RectangleCalculatorThread {
                 latitude: lat,
                 longitude: lon,
                 distance: true,
-                name:
-                    tags['name']?.toString() ?? await resolveRoadName(lat, lon),
+                name: tags['name']?.toString(),
                 maxspeed: maxspeed,
               );
               _cameraCache.add(cam);
               cams.add(cam);
               distance_cams += 1;
+              if (cam.name == null || cam.name!.isEmpty) {
+                unawaited(resolveRoadName(lat, lon).then((value) {
+                  cam.name = value;
+                  _cameraStreamController.add(cam);
+                }));
+              }
             }
             continue;
           }
@@ -2297,12 +2302,18 @@ class RectangleCalculatorThread {
               latitude: lat,
               longitude: lon,
               mobile: true,
-              name: tags['name']?.toString() ?? await resolveRoadName(lat, lon),
+              name: tags['name']?.toString(),
               maxspeed: maxspeed,
             );
             _cameraCache.add(cam);
             cams.add(cam);
             mobile_cams += 1;
+            if (cam.name == null || cam.name!.isEmpty) {
+              unawaited(resolveRoadName(lat, lon).then((value) {
+                cam.name = value;
+                _cameraStreamController.add(cam);
+              }));
+            }
             continue;
           }
 
@@ -2314,12 +2325,18 @@ class RectangleCalculatorThread {
               latitude: lat,
               longitude: lon,
               fixed: true,
-              name: tags['name']?.toString() ?? await resolveRoadName(lat, lon),
+              name: tags['name']?.toString(),
               maxspeed: maxspeed,
             );
             _cameraCache.add(cam);
             cams.add(cam);
             fix_cams += 1;
+            if (cam.name == null || cam.name!.isEmpty) {
+              unawaited(resolveRoadName(lat, lon).then((value) {
+                cam.name = value;
+                _cameraStreamController.add(cam);
+              }));
+            }
             continue;
           }
 
@@ -2329,12 +2346,18 @@ class RectangleCalculatorThread {
               latitude: lat,
               longitude: lon,
               traffic: true,
-              name: tags['name']?.toString() ?? await resolveRoadName(lat, lon),
+              name: tags['name']?.toString(),
               maxspeed: maxspeed,
             );
             _cameraCache.add(cam);
             cams.add(cam);
             traffic_cams += 1;
+            if (cam.name == null || cam.name!.isEmpty) {
+              unawaited(resolveRoadName(lat, lon).then((value) {
+                cam.name = value;
+                _cameraStreamController.add(cam);
+              }));
+            }
           }
         } catch (e, stack) {
           logger.printLogLine(

--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -190,10 +190,32 @@ class _MapPageState extends State<MapPage> {
   }
 
   void _onCameraEvent(SpeedCameraEvent cam) {
-    final exists = _markerData.values.any(
-      (c) => c.latitude == cam.latitude && c.longitude == cam.longitude,
-    );
-    if (exists) return;
+    MapEntry<Marker, SpeedCameraEvent>? existing;
+    for (final entry in _markerData.entries) {
+      if (entry.value.latitude == cam.latitude &&
+          entry.value.longitude == cam.longitude) {
+        existing = entry;
+        break;
+      }
+    }
+    if (existing != null) {
+      final oldMarker = existing.key;
+      final index = _cameraMarkers.indexOf(oldMarker);
+      final newMarker = Marker(
+        point: LatLng(cam.latitude, cam.longitude),
+        width: _markerWidthForCamera(cam),
+        height: _markerHeightForCamera(cam),
+        child: _buildCameraMarker(cam),
+      );
+      setState(() {
+        if (index != -1) {
+          _cameraMarkers[index] = newMarker;
+        }
+        _markerData.remove(oldMarker);
+        _markerData[newMarker] = cam;
+      });
+      return;
+    }
     final marker = Marker(
       point: LatLng(cam.latitude, cam.longitude),
       width: _markerWidthForCamera(cam),


### PR DESCRIPTION
## Summary
- fetch both Overpass queries in parallel within `speedCamLookupAhead`
- resolve unnamed camera road names asynchronously and update existing markers when names arrive

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95c813a64832cb31bbea848c7112e