### PR TITLE
Fix POI lookup bounding box orientation

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -341,10 +341,10 @@ class AppController {
       pts[1],
       pts[3],
     );
-    final lonMin = poly[0].x;
-    final latMin = poly[0].y;
-    final lonMax = poly[2].x;
-    final latMax = poly[2].y;
+    final lonMin = math.min(poly[0].x, poly[2].x);
+    final lonMax = math.max(poly[0].x, poly[2].x);
+    final latMin = math.min(poly[0].y, poly[2].y);
+    final latMax = math.max(poly[0].y, poly[2].y);
     final area = GeoRect(
       minLat: latMin,
       minLon: lonMin,


### PR DESCRIPTION
## Summary
- Ensure POI lookup calculates bounding box with proper min/max latitude ordering

## Testing
- `flutter test --no-test-assets` *(fails: Undefined name 'main' and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68babdb5b994832c9d3cbb20bd504ad5