### PR TITLE
feat: allow selecting GPX file from device

### DIFF
--- a/lib/gpx_loader_flutter.dart
+++ b/lib/gpx_loader_flutter.dart
@@ -1,5 +1,16 @@
+import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 
+/// Load a GPX file from either the bundled assets or an arbitrary file path.
+///
+/// The original Flutter implementation only supported loading from the
+/// application bundle via [rootBundle].  To allow users to pick GPX files from
+/// their device storage we first attempt to load the file as an asset and, if
+/// that fails, fall back to reading from the local filesystem.
 Future<String> loadGpxImpl(String path) async {
-  return rootBundle.loadString(path);
+  try {
+    return await rootBundle.loadString(path);
+  } catch (_) {
+    return File(path).readAsString();
+  }
 }

--- a/lib/ui/actions_page.dart
+++ b/lib/ui/actions_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:file_picker/file_picker.dart';
 
 import '../app_controller.dart';
 
@@ -33,8 +34,15 @@ class ActionsPage extends StatelessWidget {
             }),
             const SizedBox(height: 16),
             _buildButton(context, 'Start (GPX)', () async {
-              await controller.start(gpxFile: 'gpx/nordspange_tr2.gpx');
-              onFinished();
+              final result = await FilePicker.platform.pickFiles(
+                type: FileType.custom,
+                allowedExtensions: ['gpx'],
+              );
+              final path = result?.files.single.path;
+              if (path != null) {
+                await controller.start(gpxFile: path);
+                onFinished();
+              }
             }),
             const SizedBox(height: 16),
             _buildButton(context, 'Stop', () async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   flutter_map_marker_popup: ^8.0.1
   latlong2: ^0.9.1
   synchronized: ^3.4.0
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow choosing a GPX file via File Picker
- support loading GPX from assets or local paths
- add `file_picker` dependency

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2cecb88832cbf1da14a2d22392d