### PR TITLE
feat: allow selecting GPX file from device

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
         applicationId "com.example.workspace"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/gpx_loader_flutter.dart
+++ b/lib/gpx_loader_flutter.dart
@@ -1,5 +1,16 @@
+import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 
+/// Load a GPX file from either the bundled assets or an arbitrary file path.
+///
+/// The original Flutter implementation only supported loading from the
+/// application bundle via [rootBundle].  To allow users to pick GPX files from
+/// their device storage we first attempt to load the file as an asset and, if
+/// that fails, fall back to reading from the local filesystem.
 Future<String> loadGpxImpl(String path) async {
-  return rootBundle.loadString(path);
+  try {
+    return await rootBundle.loadString(path);
+  } catch (_) {
+    return File(path).readAsString();
+  }
 }

--- a/lib/ui/actions_page.dart
+++ b/lib/ui/actions_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:file_selector/file_selector.dart';
 
 import '../app_controller.dart';
 
@@ -33,8 +34,17 @@ class ActionsPage extends StatelessWidget {
             }),
             const SizedBox(height: 16),
             _buildButton(context, 'Start (GPX)', () async {
-              await controller.start(gpxFile: 'gpx/nordspange_tr2.gpx');
-              onFinished();
+              final typeGroup = XTypeGroup(
+                label: 'GPX',
+                extensions: ['gpx'],
+              );
+              final file =
+                  await openFile(acceptedTypeGroups: [typeGroup]);
+              final path = file?.path;
+              if (path != null) {
+                await controller.start(gpxFile: path);
+                onFinished();
+              }
             }),
             const SizedBox(height: 16),
             _buildButton(context, 'Stop', () async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   flutter_map_marker_popup: ^8.0.1
   latlong2: ^0.9.1
   synchronized: ^3.4.0
+  file_selector: ^1.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- use file_selector to pick GPX files
- support loading GPX from assets or local paths
- raise Android minSdk to 23 to satisfy camera dependency

## Testing
- `dart format lib/gpx_loader_flutter.dart lib/ui/actions_page.dart pubspec.yaml android/app/build.gradle` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2cecb88832cbf1da14a2d22392d