### PR TITLE
Adjust camera marker dimensions for direction

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -206,6 +206,7 @@ class _MapPageState extends State<MapPage> {
     if (cam.maxspeed != null) height += 28;
     if (cam.predictive) height += 28;
     if (cam.name != null && cam.name!.isNotEmpty) height += 28;
+    if (cam.direction != null && cam.direction!.isNotEmpty) height += 28;
     return height;
   }
 
@@ -213,7 +214,9 @@ class _MapPageState extends State<MapPage> {
     var width = 40.0;
     if (cam.name != null && cam.name!.isNotEmpty) {
       width = 160.0;
-    } else if (cam.predictive || cam.maxspeed != null) {
+    } else if (cam.predictive ||
+        cam.maxspeed != null ||
+        (cam.direction != null && cam.direction!.isNotEmpty)) {
       width = 100.0;
     }
     return width;


### PR DESCRIPTION
## Summary
- account for camera direction when calculating marker dimensions to avoid overflow

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd735a0844832c8f3777c098b27c0a