### PR TITLE
feat: show upcoming speed camera

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -524,6 +524,12 @@ class RectangleCalculatorThread {
   final ValueNotifier<String?> cameraRoadNotifier = ValueNotifier<String?>(
     null,
   );
+  final ValueNotifier<String?> nextCamRoadNotifier =
+      ValueNotifier<String?>(null);
+  final ValueNotifier<int?> nextCamDistanceNotifier =
+      ValueNotifier<int?>(null);
+  final ValueNotifier<bool> processNextCamNotifier =
+      ValueNotifier<bool>(false);
   final ValueNotifier<LatLng> positionNotifier = ValueNotifier<LatLng>(
     const LatLng(0, 0),
   );
@@ -3169,4 +3175,19 @@ class RectangleCalculatorThread {
       speedCamDistanceNotifier.value = meter;
 
   void updateCameraRoad(String? road) => cameraRoadNotifier.value = road;
+
+  void updateNextCamInfo({
+    required bool process,
+    String? road,
+    int? distance,
+  }) {
+    processNextCamNotifier.value = process;
+    if (process) {
+      nextCamRoadNotifier.value = road;
+      nextCamDistanceNotifier.value = distance;
+    } else {
+      nextCamRoadNotifier.value = null;
+      nextCamDistanceNotifier.value = null;
+    }
+  }
 }

--- a/lib/speed_cam_warner.dart
+++ b/lib/speed_cam_warner.dart
@@ -738,6 +738,13 @@ class SpeedCamWarner {
     int nextCamDistanceAsInt = 0,
     bool processNextCam = false,
   }) {
+    if (resume?.isResumed() ?? true) {
+      updateNextCam(
+        process: processNextCam,
+        road: processNextCam ? nextCamRoad : null,
+        distance: processNextCam ? nextCamDistanceAsInt : null,
+      );
+    }
     if (distance >= 0 && distance <= 100) {
       camInProgress = true;
       if (lastDistance == -1 || lastDistance > 100) {
@@ -1028,6 +1035,18 @@ class SpeedCamWarner {
     } else {
       calculator.updateMaxspeed(maxSpeed);
     }
+  }
+
+  void updateNextCam({
+    required bool process,
+    String? road,
+    int? distance,
+  }) {
+    calculator.updateNextCamInfo(
+      process: process,
+      road: road,
+      distance: distance,
+    );
   }
 
   LatLng? get lastPosition => _lastPosition;

--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -44,6 +44,9 @@ class _DashboardPageState extends State<DashboardPage> {
   String? _speedCamIcon;
   double? _speedCamDistance;
   String? _cameraRoad;
+  String? _nextCamRoad;
+  int? _nextCamDistance;
+  bool _processNextCam = false;
   int? _maxSpeed;
   bool _gpsOn = false;
   bool _online = false;
@@ -78,6 +81,9 @@ class _DashboardPageState extends State<DashboardPage> {
         _speedCamDistance = _calculator!.speedCamDistanceNotifier.value;
         _cameraRoad = _calculator!.cameraRoadNotifier.value;
       }
+      _nextCamRoad = _calculator!.nextCamRoadNotifier.value;
+      _nextCamDistance = _calculator!.nextCamDistanceNotifier.value;
+      _processNextCam = _calculator!.processNextCamNotifier.value;
       _maxSpeed = _calculator!.maxspeedNotifier.value;
       _overspeedDiff = (_maxSpeed != null && _speed > _maxSpeed!)
           ? (_speed - _maxSpeed!).round()
@@ -88,6 +94,9 @@ class _DashboardPageState extends State<DashboardPage> {
       _calculator!.speedCamNotifier.addListener(_updateFromCalculator);
       _calculator!.speedCamDistanceNotifier.addListener(_updateFromCalculator);
       _calculator!.cameraRoadNotifier.addListener(_updateFromCalculator);
+      _calculator!.nextCamRoadNotifier.addListener(_updateFromCalculator);
+      _calculator!.nextCamDistanceNotifier.addListener(_updateFromCalculator);
+      _calculator!.processNextCamNotifier.addListener(_updateFromCalculator);
       _calculator!.maxspeedNotifier.addListener(_updateFromCalculator);
       _calculator!.gpsStatusNotifier.addListener(_updateFromCalculator);
       _calculator!.onlineStatusNotifier.addListener(_updateFromCalculator);
@@ -128,6 +137,9 @@ class _DashboardPageState extends State<DashboardPage> {
         _cameraRoad = _calculator!.cameraRoadNotifier.value;
         _speedCamIcon = _iconForWarning(_speedCamWarning);
       }
+      _nextCamRoad = _calculator!.nextCamRoadNotifier.value;
+      _nextCamDistance = _calculator!.nextCamDistanceNotifier.value;
+      _processNextCam = _calculator!.processNextCamNotifier.value;
       _gpsOn = _calculator!.gpsStatusNotifier.value;
       _online = _calculator!.onlineStatusNotifier.value;
       _speedHistory.add(_speed);
@@ -277,6 +289,9 @@ class _DashboardPageState extends State<DashboardPage> {
         _updateFromCalculator,
       );
       _calculator!.cameraRoadNotifier.removeListener(_updateFromCalculator);
+      _calculator!.nextCamRoadNotifier.removeListener(_updateFromCalculator);
+      _calculator!.nextCamDistanceNotifier.removeListener(_updateFromCalculator);
+      _calculator!.processNextCamNotifier.removeListener(_updateFromCalculator);
       _calculator!.maxspeedNotifier.removeListener(_updateFromCalculator);
       _calculator!.gpsStatusNotifier.removeListener(_updateFromCalculator);
       _calculator!.onlineStatusNotifier.removeListener(_updateFromCalculator);
@@ -333,6 +348,13 @@ class _DashboardPageState extends State<DashboardPage> {
               left: 0,
               right: 0,
               child: _buildCameraInfo(),
+            ),
+          if (_processNextCam)
+            Positioned(
+              top: hasCameraInfo ? 120 : 16,
+              left: 0,
+              right: 0,
+              child: _buildNextCameraInfo(),
             ),
         ],
       ),
@@ -431,6 +453,38 @@ class _DashboardPageState extends State<DashboardPage> {
                     style: const TextStyle(color: Colors.white70, fontSize: 12),
                   ),
               ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNextCameraInfo() {
+    if (!_processNextCam || _nextCamRoad == null || _nextCamDistance == null) {
+      return const SizedBox.shrink();
+    }
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.blueGrey.withOpacity(0.7),
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: const [
+          BoxShadow(color: Colors.black26, blurRadius: 8, offset: Offset(0, 4)),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.camera_alt, color: Colors.white),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Next: $_nextCamRoad (${_nextCamDistance!} m)',
+              style: const TextStyle(color: Colors.white, fontSize: 16),
+              overflow: TextOverflow.ellipsis,
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- surface upcoming speed camera info from calculation thread
- display future camera card when available on dashboard

## Testing
- `dart format lib/rectangle_calculator.dart lib/speed_cam_warner.dart lib/ui/dashboard.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb9f0afe0832c85b4f8c2f28fad3f