### PR TITLE
Display next camera widget below active camera

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -380,19 +380,21 @@ class _DashboardPageState extends State<DashboardPage> {
               ],
             ),
           ),
-          if (hasCameraInfo)
-            Positioned(
-              top: 16,
-              left: 0,
-              right: 0,
-              child: _buildCameraInfo(),
-            ),
-          if (_processNextCam)
-            Positioned(
-              top: hasCameraInfo ? 120 : 16,
-              left: 0,
-              right: 0,
-              child: _buildNextCameraInfo(),
+          if (hasCameraInfo || _processNextCam)
+            Align(
+              alignment: Alignment.topCenter,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (hasCameraInfo) _buildCameraInfo(),
+                    if (hasCameraInfo && _processNextCam)
+                      const SizedBox(height: 8),
+                    if (_processNextCam) _buildNextCameraInfo(),
+                  ],
+                ),
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Ensure next camera info widget is stacked beneath the active camera info without overlaying

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beda3ef96c832cae74639fa17d7826