### PR TITLE
feat: beep when exceeding camera speed

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -11,6 +11,7 @@ import 'gps_producer.dart';
 import 'speed_cam_warner.dart';
 import 'voice_prompt_thread.dart';
 import 'overspeed_checker.dart';
+import 'overspeed_beeper.dart';
 import 'config.dart';
 import 'thread_base.dart';
 import 'dialogflow_client.dart';
@@ -27,6 +28,7 @@ class AppController {
       : voicePromptEvents = VoicePromptEvents(),
         locationManager = LocationManager() {
     overspeedChecker = OverspeedChecker();
+    overspeedBeeper = OverspeedBeeper(checker: overspeedChecker);
 
     // Start the deviation checker by default so it can be paused during AR
     // sessions and restarted afterwards.
@@ -124,6 +126,9 @@ class AppController {
 
   /// Publishes the current overspeed difference to the UI.
   late final OverspeedChecker overspeedChecker;
+
+  /// Plays a warning tone when overspeed is detected.
+  late final OverspeedBeeper overspeedBeeper;
 
   /// Calculates deviation of the current course based on recent bearings.
   late deviation.DeviationCheckerThread deviationChecker;
@@ -228,6 +233,7 @@ class AppController {
     await calculator.dispose();
     poiReader.stopTimer();
     await voiceThread.stop();
+    await overspeedBeeper.dispose();
     stopDeviationCheckerThread();
     await _poiController.close();
   }

--- a/lib/overspeed_beeper.dart
+++ b/lib/overspeed_beeper.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'overspeed_checker.dart';
+
+/// Plays a short beep sequence whenever the current speed exceeds the last
+/// provided speed limit.
+///
+/// The [OverspeedChecker] publishes the difference between the current speed and
+/// the configured speed limit. This helper listens to that notifier and emits
+/// three short beeps when the difference becomes positive. Once the speed drops
+/// back below the limit the warning is reset and can trigger again.
+class OverspeedBeeper {
+  final OverspeedChecker checker;
+  late final VoidCallback _listener;
+
+  bool _alerted = false;
+
+  OverspeedBeeper({required this.checker}) {
+    _listener = _handleChange;
+    checker.difference.addListener(_listener);
+  }
+
+  void _handleChange() {
+    final diff = checker.difference.value;
+    if (diff != null && diff > 0) {
+      if (!_alerted) {
+        _alerted = true;
+        _beepThreeTimes();
+      }
+    } else {
+      // Reset once we are back under the limit.
+      _alerted = false;
+    }
+  }
+
+  Future<void> _beepThreeTimes() async {
+    for (var i = 0; i < 3; i++) {
+      try {
+        await SystemSound.play(SystemSoundType.alert);
+      } catch (_) {
+        // Ignore any audio errors in headless environments.
+      }
+      // Wait a bit before playing the next beep.
+      await Future.delayed(const Duration(milliseconds: 200));
+    }
+  }
+
+  Future<void> dispose() async {
+    checker.difference.removeListener(_listener);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add OverspeedBeeper service to play three beeps when speed exceeds limit and reset when back under
- integrate overspeed beeper into app controller
- remove external beep sound asset and rely on system alert tone

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4f2cda2c832c81c1e1e6981940b7