### PR TITLE
feat: enable background execution

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
+import 'package:flutter_background/flutter_background.dart';
 import 'app_controller.dart';
 import 'config.dart';
 import 'ui/home.dart';
@@ -12,6 +13,19 @@ import 'ui/home.dart';
 /// [AppController].
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  const androidConfig = FlutterBackgroundAndroidConfig(
+    notificationTitle: 'SpeedCamWarner',
+    notificationText: 'Background service running',
+    notificationImportance: AndroidNotificationImportance.low,
+    enableWifiLock: true,
+  );
+  try {
+    await FlutterBackground.initialize(androidConfig: androidConfig);
+    await FlutterBackground.enableBackgroundExecution();
+  } catch (e) {
+    // ignore: avoid_print
+    print('Background initialisation failed: $e');
+  }
   await AppConfig.load();
   runApp(SpeedCamWarnerApp());
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -366,6 +366,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_background:
+    dependency: "direct main"
+    description:
+      name: flutter_background
+      sha256: "8dad66e3102da2b4046cc3adcf70625578809827170bd78e36e5890c074287d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0+1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   latlong2: ^0.9.1
   synchronized: ^3.4.0
   file_selector: ^1.0.2
+  flutter_background: ^1.3.0+1
   flutter_local_notifications: ^17.1.2
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add flutter_background dependency
- initialize background service so app keeps running when minimized

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `dart test` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68c059be3854832ca26482dc02cc3017