### PR TITLE
Add speed camera clustering on map

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   googleapis_auth: ^1.4.1
   flutter_map: ^8.2.1
   flutter_map_marker_popup: ^8.0.1
+  flutter_map_marker_cluster: ^8.1.0
   latlong2: ^0.9.1
   synchronized: ^3.4.0
   file_selector: ^1.0.2


### PR DESCRIPTION
## Summary
- cluster camera markers with `flutter_map_marker_cluster`
- centralize popup builder and keep popups for POIs and construction areas
- add `flutter_map_marker_cluster` dependency
- wrap `FlutterMap` in `PopupScope` to provide popup state
- style cluster bubbles and share popup controller so cameras display correctly
- rebuild marker lists when their contents change so clusters refresh

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c523b94d0c832c8e17ff2d96744938