### PR TITLE
Add speed camera clustering on map

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_popup/flutter_map_marker_popup.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../rectangle_calculator.dart';
@@ -38,11 +39,11 @@ class MapPage extends StatefulWidget {
 class _MapPageState extends State<MapPage> {
   late LatLng _center;
   Marker? _gpsMarker;
-  final List<Marker> _cameraMarkers = [];
-  final List<Marker> _poiMarkers = [];
-  final Map<Marker, List<dynamic>> _poiData = {};
+  List<Marker> _cameraMarkers = [];
+  List<Marker> _poiMarkers = [];
+  Map<Marker, List<dynamic>> _poiData = {};
   final Map<Marker, SpeedCameraEvent> _markerData = {};
-  final List<Marker> _constructionMarkers = [];
+  List<Marker> _constructionMarkers = [];
   final Map<Marker, GeoRect> _constructionData = {};
   final PopupController _popupController = PopupController();
   final MapController _mapController = MapController();
@@ -276,6 +277,50 @@ class _MapPageState extends State<MapPage> {
     );
   }
 
+  Widget _buildMarkerPopup(Marker marker) {
+    final cam = _markerData[marker];
+    if (cam != null) {
+      final types = <String>[
+        if (cam.fixed) 'fixed',
+        if (cam.traffic) 'traffic',
+        if (cam.distance) 'distance',
+        if (cam.mobile) 'mobile',
+        if (cam.predictive) 'predictive',
+      ].join(', ');
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                (cam.name != null && cam.name!.isNotEmpty)
+                    ? cam.name!
+                    : 'Speed camera',
+              ),
+              if (types.isNotEmpty)
+                Text(types, style: const TextStyle(fontSize: 12)),
+            ],
+          ),
+        ),
+      );
+    }
+    final poi = _poiData[marker];
+    if (poi != null) {
+      return _buildPoiPopup(poi);
+    }
+    if (_constructionData.containsKey(marker)) {
+      return const Card(
+        child: Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Text('Construction area'),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
   void _onCameraEvent(SpeedCameraEvent cam) {
     MapEntry<Marker, SpeedCameraEvent>? existing;
     for (final entry in _markerData.entries) {
@@ -296,10 +341,15 @@ class _MapPageState extends State<MapPage> {
       );
       setState(() {
         if (index != -1) {
-          _cameraMarkers[index] = newMarker;
+          final updated = List<Marker>.from(_cameraMarkers);
+          updated[index] = newMarker;
+          _cameraMarkers = updated;
+        } else {
+          _cameraMarkers = [..._cameraMarkers, newMarker];
         }
-        _markerData.remove(oldMarker);
-        _markerData[newMarker] = cam;
+        _markerData
+          ..remove(oldMarker)
+          ..[newMarker] = cam;
       });
       return;
     }
@@ -310,7 +360,7 @@ class _MapPageState extends State<MapPage> {
       child: _buildCameraMarker(cam),
     );
     setState(() {
-      _cameraMarkers.add(marker);
+      _cameraMarkers = [..._cameraMarkers, marker];
       _markerData[marker] = cam;
     });
   }
@@ -333,7 +383,7 @@ class _MapPageState extends State<MapPage> {
     }
     if (newMarkers.isEmpty) return;
     setState(() {
-      _cameraMarkers.addAll(newMarkers);
+      _cameraMarkers = [..._cameraMarkers, ...newMarkers];
     });
   }
 
@@ -350,7 +400,8 @@ class _MapPageState extends State<MapPage> {
     }
     if (markerToRemove != null) {
       setState(() {
-        _cameraMarkers.remove(markerToRemove);
+        _cameraMarkers =
+            _cameraMarkers.where((m) => m != markerToRemove).toList();
         _markerData.remove(markerToRemove);
       });
     }
@@ -398,7 +449,7 @@ class _MapPageState extends State<MapPage> {
     }
     if (newMarkers.isEmpty && newPolygons.isEmpty) return;
     setState(() {
-      _constructionMarkers.addAll(newMarkers);
+      _constructionMarkers = [..._constructionMarkers, ...newMarkers];
       _constructionPolygons = [..._constructionPolygons, ...newPolygons];
     });
   }
@@ -455,78 +506,58 @@ class _MapPageState extends State<MapPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Map')),
-      body: FlutterMap(
-        mapController: _mapController,
-        options: MapOptions(initialCenter: _center, initialZoom: 15),
-        children: [
-          TileLayer(
-            urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-            userAgentPackageName: 'com.example.speedcamwarner',
-          ),
-          if (_rectPolygons.isNotEmpty || _constructionPolygons.isNotEmpty)
-            PolygonLayer(
-              polygons: [
-                ..._rectPolygons,
-                ..._constructionPolygons,
-              ],
+      body: PopupScope(
+        popupController: _popupController,
+        child: FlutterMap(
+          mapController: _mapController,
+          options: MapOptions(initialCenter: _center, initialZoom: 15),
+          children: [
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.example.speedcamwarner',
             ),
-          if (_gpsMarker != null) MarkerLayer(markers: [_gpsMarker!]),
-          PopupMarkerLayer(
-            options: PopupMarkerLayerOptions(
-              popupController: _popupController,
-              markers: [
-                ..._cameraMarkers,
-                ..._constructionMarkers,
-                ..._poiMarkers
-              ],
-              popupDisplayOptions: PopupDisplayOptions(
-                builder: (context, marker) {
-                  final cam = _markerData[marker];
-                  if (cam != null) {
-                    final types = <String>[
-                      if (cam.fixed) 'fixed',
-                      if (cam.traffic) 'traffic',
-                      if (cam.distance) 'distance',
-                      if (cam.mobile) 'mobile',
-                      if (cam.predictive) 'predictive',
-                    ].join(', ');
-                    return Card(
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              (cam.name != null && cam.name!.isNotEmpty)
-                                  ? cam.name!
-                                  : 'Speed camera',
-                            ),
-                            if (types.isNotEmpty)
-                              Text(types, style: const TextStyle(fontSize: 12)),
-                          ],
-                        ),
-                      ),
-                    );
-                  }
-                  final poi = _poiData[marker];
-                  if (poi != null) {
-                    return _buildPoiPopup(poi);
-                  }
-                  if (_constructionData.containsKey(marker)) {
-                    return const Card(
-                      child: Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: Text('Construction area'),
-                      ),
-                    );
-                  }
-                  return const SizedBox.shrink();
-                },
+            if (_rectPolygons.isNotEmpty || _constructionPolygons.isNotEmpty)
+              PolygonLayer(
+                polygons: [
+                  ..._rectPolygons,
+                  ..._constructionPolygons,
+                ],
+              ),
+            if (_gpsMarker != null) MarkerLayer(markers: [_gpsMarker!]),
+            MarkerClusterLayerWidget(
+              options: MarkerClusterLayerOptions(
+                markers: _cameraMarkers,
+                maxClusterRadius: 45,
+                disableClusteringAtZoom: 16,
+                size: const Size(40, 40),
+                alignment: Alignment.center,
+                builder: (context, markers) => CircleAvatar(
+                  backgroundColor: Colors.blue,
+                  child: Text(
+                    markers.length.toString(),
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+                popupOptions: PopupOptions(
+                  popupController: _popupController,
+                  popupBuilder: (context, marker) => _buildMarkerPopup(marker),
+                ),
               ),
             ),
-          ),
-        ],
+            PopupMarkerLayer(
+              options: PopupMarkerLayerOptions(
+                popupController: _popupController,
+                markers: [
+                  ..._constructionMarkers,
+                  ..._poiMarkers
+                ],
+                popupDisplayOptions: PopupDisplayOptions(
+                  builder: (context, marker) => _buildMarkerPopup(marker),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
       floatingActionButton: Column(
         mainAxisSize: MainAxisSize.min,
@@ -567,12 +598,8 @@ class _MapPageState extends State<MapPage> {
       }
     }
     setState(() {
-      _poiMarkers
-        ..clear()
-        ..addAll(markers);
-      _poiData
-        ..clear()
-        ..addAll(data);
+      _poiMarkers = markers;
+      _poiData = data;
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   googleapis_auth: ^1.4.1
   flutter_map: ^8.2.1
   flutter_map_marker_popup: ^8.0.1
+  flutter_map_marker_cluster: ^8.1.0
   latlong2: ^0.9.1
   synchronized: ^3.4.0
   file_selector: ^1.0.2


### PR DESCRIPTION
## Summary
- cluster camera markers with `flutter_map_marker_cluster`
- centralize popup builder and keep popups for POIs and construction areas
- add `flutter_map_marker_cluster` dependency
- wrap `FlutterMap` in `PopupScope` to provide popup state
- style cluster bubbles and share popup controller so cameras display correctly
- rebuild marker lists when their contents change so clusters refresh
- make camera, POI, and construction marker lists mutable for reassignment

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c523b94d0c832c8e17ff2d96744938