### PR TITLE
Fix speed gauge start color

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -1173,7 +1173,7 @@ class _SpeedRingPainter extends CustomPainter {
       ..shader = gradient.createShader(rect)
       ..style = PaintingStyle.stroke
       ..strokeWidth = _strokeWidth
-      ..strokeCap = StrokeCap.round;
+      ..strokeCap = StrokeCap.butt;
 
     final Color tipColor = _colorAtProgress(clampedProgress);
     final double glowOpacity =
@@ -1186,6 +1186,15 @@ class _SpeedRingPainter extends CustomPainter {
 
     canvas.drawArc(rect, startAngle, sweepAngle, false, glowPaint);
     canvas.drawArc(rect, startAngle, sweepAngle, false, ringPaint);
+
+    final Offset startPosition = Offset(
+      center.dx + radius * math.cos(startAngle),
+      center.dy + radius * math.sin(startAngle),
+    );
+    final Paint startCapPaint = Paint()
+      ..color = _colorAtProgress(0.0)
+      ..style = PaintingStyle.fill;
+    canvas.drawCircle(startPosition, _strokeWidth / 2, startCapPaint);
 
     final double indicatorAngle = startAngle + sweepAngle;
     final Offset indicatorPosition = Offset(


### PR DESCRIPTION
## Summary
- ensure the speed ring starts with the low-speed color by overlaying a start cap that matches the beginning of the gradient
- prevent the gradient stroke from bleeding in the pink high-speed color at the start of the gauge by switching the ring paint to a butt stroke cap

## Testing
- not run (flutter command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd2774d90c832cbbb64f204b45bf0e