### PR TITLE
Fix speed gauge start color

### DIFF
--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -1158,22 +1158,34 @@ class _SpeedRingPainter extends CustomPainter {
       ..strokeWidth = _strokeWidth;
     canvas.drawArc(rect, startAngle, 2 * math.pi, false, trackPaint);
 
-    if (clampedProgress <= 0) {
+    if (clampedProgress <= 0.0001) {
       return;
     }
 
+    if (colors.isEmpty || stops.isEmpty) {
+      return;
+    }
+
+    final List<Color> gradientColors = <Color>[
+      colors.first.withOpacity(0.0),
+      ...colors,
+    ];
+    final List<double> gradientStops = <double>[
+      0.0,
+      ...stops.map((stop) => stop == 0.0 ? 0.0001 : stop),
+    ];
     final SweepGradient gradient = SweepGradient(
       startAngle: startAngle,
       endAngle: startAngle + 2 * math.pi,
-      colors: colors,
-      stops: stops,
+      colors: gradientColors,
+      stops: gradientStops,
       tileMode: TileMode.clamp,
     );
     final Paint ringPaint = Paint()
       ..shader = gradient.createShader(rect)
       ..style = PaintingStyle.stroke
       ..strokeWidth = _strokeWidth
-      ..strokeCap = StrokeCap.round;
+      ..strokeCap = StrokeCap.butt;
 
     final Color tipColor = _colorAtProgress(clampedProgress);
     final double glowOpacity =


### PR DESCRIPTION
## Summary
- keep the speed ring blank at standstill by adding a transparent lead-in stop to the gradient and ignoring imperceptible progress values
- remove the manual start cap so the gauge no longer shows stray high-speed color at the top of the dial

## Testing
- not run (`flutter` command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd2774d90c832cbbb64f204b45bf0e