### PR TITLE
Fix overspeed checker not receiving string limits

### DIFF
--- a/lib/rectangle_calculator.dart
+++ b/lib/rectangle_calculator.dart
@@ -1068,8 +1068,7 @@ class RectangleCalculatorThread {
     // warn the driver when necessary. The GPS thread provides the current
     // speed updates directly.
     final dynamic lms = lastMaxSpeed;
-    final int? limit = (lms is int) ? lms : null;
-    overspeedChecker.updateLimit(limit);
+    overspeedChecker.updateLimit(lms);
 
     // Handle possible look-ahead interrupts.
     if (camerasLookAheadMode) {


### PR DESCRIPTION
## Summary
- forward the last max speed value directly to the overspeed checker
- allow overspeed warnings to trigger even when limits are provided as strings

## Testing
- not run (flutter is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d3b83f2a44832c837688a67422da58