### PR TITLE
Cluster POI markers on map

### DIFF
--- a/lib/ui/map_page.dart
+++ b/lib/ui/map_page.dart
@@ -544,13 +544,30 @@ class _MapPageState extends State<MapPage> {
                 ),
               ),
             ),
+            MarkerClusterLayerWidget(
+              options: MarkerClusterLayerOptions(
+                markers: _poiMarkers,
+                maxClusterRadius: 45,
+                disableClusteringAtZoom: 16,
+                size: const Size(40, 40),
+                alignment: Alignment.center,
+                builder: (context, markers) => CircleAvatar(
+                  backgroundColor: Colors.green,
+                  child: Text(
+                    markers.length.toString(),
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+                popupOptions: PopupOptions(
+                  popupController: _popupController,
+                  popupBuilder: (context, marker) => _buildMarkerPopup(marker),
+                ),
+              ),
+            ),
             PopupMarkerLayer(
               options: PopupMarkerLayerOptions(
                 popupController: _popupController,
-                markers: [
-                  ..._constructionMarkers,
-                  ..._poiMarkers
-                ],
+                markers: _constructionMarkers,
                 popupDisplayOptions: PopupDisplayOptions(
                   builder: (context, marker) => _buildMarkerPopup(marker),
                 ),


### PR DESCRIPTION
## Summary
- add a marker cluster layer for fuel and hospital POIs so they group like speed cameras
- keep construction markers on the popup layer while POI popups are handled by the new cluster

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9249b3da0832cbf05a6990fa28398