### PR TITLE
Connect overspeed checker to GPS thread

### DIFF
--- a/lib/app_controller.dart
+++ b/lib/app_controller.dart
@@ -43,6 +43,7 @@ class AppController {
     gps = GpsThread(
       voicePromptEvents: voicePromptEvents,
       speedCamEventController: calculator.speedCamEventController,
+      overspeedChecker: overspeedChecker,
     );
     // Pipe GPS samples into the calculator and GPS producer and expose
     // direction updates to the UI and other threads. Position updates are


### PR DESCRIPTION
## Summary
- wire the overspeed checker into the GPS thread so overspeed listeners receive updates

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de5346b240832c945ab60dac72533e