### PR TITLE
Fix face/body detection metadata

### DIFF
--- a/lib/ar_layout.dart
+++ b/lib/ar_layout.dart
@@ -174,11 +174,19 @@ class EdgeDetectState extends State<EdgeDetect> {
       final InputImageFormat format =
           InputImageFormatValue.fromRawValue(image.format.raw) ??
               InputImageFormat.nv21;
+      final List<InputImagePlaneMetadata> planeData = image.planes
+          .map((Plane plane) => InputImagePlaneMetadata(
+                bytesPerRow: plane.bytesPerRow,
+                height: plane.height,
+                width: plane.width,
+              ))
+          .toList();
       final metadata = InputImageMetadata(
         size: imageSize,
         rotation: rotation,
         format: format,
         bytesPerRow: image.planes.first.bytesPerRow,
+        planeData: planeData,
       );
       final InputImage inputImage =
           InputImage.fromBytes(bytes: bytes, metadata: metadata);


### PR DESCRIPTION
## Summary
- add ML Kit plane metadata when building InputImage for AR detection
- ensure face and body detectors receive complete frame information for reliable results

## Testing
- dart analyze *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e003d770ec832c82de512622eabc01