### PR TITLE
Handle missing cameras when connecting AR view

### DIFF
--- a/lib/ar_layout.dart
+++ b/lib/ar_layout.dart
@@ -168,6 +168,13 @@ class EdgeDetectState extends State<EdgeDetect> {
     }
 
     final List<CameraDescription> cameras = await availableCameras();
+    if (cameras.isEmpty) {
+      const warning = 'connectCamera aborted: no cameras available';
+      _logViewer?.call('No available cameras found');
+      debugPrint(warning);
+      return;
+    }
+
     final CameraDescription description = cameras.firstWhere(
       (CameraDescription d) => _cameraDirection == 'front'
           ? d.lensDirection == CameraLensDirection.front


### PR DESCRIPTION
## Summary
- guard the AR camera initialization against the absence of any available cameras
- notify the log viewer and debug output when initialization is skipped due to missing cameras

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c5237eec832cb90aae935812f0eb