### PR TITLE
Replace AR tab with drive insights dashboard

### DIFF
--- a/lib/drive_history_recorder.dart
+++ b/lib/drive_history_recorder.dart
@@ -1,0 +1,359 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import 'gps_producer.dart';
+import 'overspeed_checker.dart';
+import 'rectangle_calculator.dart';
+
+/// Types of events captured during a driving session.
+enum DriveEventKind { speedCamera, construction, overspeed }
+
+/// Immutable record describing a notable driving event such as passing a speed
+/// camera, encountering roadworks or driving above the speed limit.
+class DriveEvent {
+  const DriveEvent({
+    required this.id,
+    required this.kind,
+    required this.timestamp,
+    required this.latitude,
+    required this.longitude,
+    required this.title,
+    this.subtitle,
+    this.details = const <String, dynamic>{},
+    this.endTimestamp,
+    this.isOngoing = false,
+    this.maxOverspeed,
+  });
+
+  final int id;
+  final DriveEventKind kind;
+  final DateTime timestamp;
+  final double latitude;
+  final double longitude;
+  final String title;
+  final String? subtitle;
+  final Map<String, dynamic> details;
+  final DateTime? endTimestamp;
+  final bool isOngoing;
+  final int? maxOverspeed;
+
+  /// Returns the duration between [timestamp] and [endTimestamp] (or now if the
+  /// event is still ongoing).
+  Duration? get duration {
+    if (endTimestamp != null) {
+      return endTimestamp!.difference(timestamp);
+    }
+    if (isOngoing) {
+      return DateTime.now().difference(timestamp);
+    }
+    return null;
+  }
+
+  DriveEvent copyWith({
+    double? latitude,
+    double? longitude,
+    String? title,
+    String? subtitle,
+    Map<String, dynamic>? details,
+    DateTime? timestamp,
+    DateTime? endTimestamp,
+    bool? isOngoing,
+    int? maxOverspeed,
+  }) {
+    return DriveEvent(
+      id: id,
+      kind: kind,
+      timestamp: timestamp ?? this.timestamp,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      details: details ?? this.details,
+      endTimestamp: endTimestamp ?? this.endTimestamp,
+      isOngoing: isOngoing ?? this.isOngoing,
+      maxOverspeed: maxOverspeed ?? this.maxOverspeed,
+    );
+  }
+}
+
+/// Aggregated session metrics derived from recorded events.
+class DriveSessionSummary {
+  const DriveSessionSummary({
+    required this.speedCameraCount,
+    required this.constructionCount,
+    required this.overspeedCount,
+    required this.overspeedDuration,
+    required this.maxOverspeed,
+  });
+
+  factory DriveSessionSummary.empty() => const DriveSessionSummary(
+        speedCameraCount: 0,
+        constructionCount: 0,
+        overspeedCount: 0,
+        overspeedDuration: Duration.zero,
+        maxOverspeed: 0,
+      );
+
+  final int speedCameraCount;
+  final int constructionCount;
+  final int overspeedCount;
+  final Duration overspeedDuration;
+  final int maxOverspeed;
+
+  DriveSessionSummary copyWith({
+    int? speedCameraCount,
+    int? constructionCount,
+    int? overspeedCount,
+    Duration? overspeedDuration,
+    int? maxOverspeed,
+  }) {
+    return DriveSessionSummary(
+      speedCameraCount: speedCameraCount ?? this.speedCameraCount,
+      constructionCount: constructionCount ?? this.constructionCount,
+      overspeedCount: overspeedCount ?? this.overspeedCount,
+      overspeedDuration: overspeedDuration ?? this.overspeedDuration,
+      maxOverspeed: maxOverspeed ?? this.maxOverspeed,
+    );
+  }
+}
+
+/// Captures drive events by listening to calculator streams and the
+/// [OverspeedChecker]. Consumers can present the accumulated events through a
+/// [ValueListenable] or reset the recorder when a new session starts.
+class DriveHistoryRecorder {
+  DriveHistoryRecorder({
+    required this.calculator,
+    required this.overspeedChecker,
+    required this.gpsProducer,
+  }) {
+    _subscriptions
+        .add(calculator.cameras.listen((event) => _onCamera(event)));
+    _subscriptions.add(
+      calculator.constructions.listen((rect) {
+        if (rect != null) {
+          _onConstruction(rect);
+        }
+      }),
+    );
+    overspeedChecker.difference.addListener(_onOverspeed);
+  }
+
+  final RectangleCalculatorThread calculator;
+  final OverspeedChecker overspeedChecker;
+  final GpsProducer gpsProducer;
+
+  final ValueNotifier<List<DriveEvent>> events =
+      ValueNotifier<List<DriveEvent>>(const <DriveEvent>[]);
+  final ValueNotifier<DriveSessionSummary> summary =
+      ValueNotifier<DriveSessionSummary>(DriveSessionSummary.empty());
+
+  final List<StreamSubscription<dynamic>> _subscriptions =
+      <StreamSubscription<dynamic>>[];
+  DriveEvent? _activeOverspeed;
+  Timer? _overspeedTicker;
+  Duration _completedOverspeedDuration = Duration.zero;
+  Duration _activeOverspeedDuration = Duration.zero;
+  int _eventId = 0;
+
+  /// Reset the recorder, clearing all events and metrics.
+  void reset() {
+    _completedOverspeedDuration = Duration.zero;
+    _activeOverspeedDuration = Duration.zero;
+    _activeOverspeed = null;
+    _cancelTicker();
+    events.value = const <DriveEvent>[];
+    summary.value = DriveSessionSummary.empty();
+  }
+
+  /// Called when a driving session is about to start.
+  void startSession() {
+    reset();
+  }
+
+  /// Finalises ongoing events (if any) at the end of a session.
+  void endSession() {
+    _finaliseActiveOverspeed();
+  }
+
+  void _onCamera(SpeedCameraEvent event) {
+    final String cameraLabel = event.name?.trim().isNotEmpty == true
+        ? event.name!.trim()
+        : 'Speed camera';
+    final String? subtitle = event.maxspeed != null
+        ? 'Limit ${event.maxspeed} km/h'
+        : (event.direction != null ? 'Direction ${event.direction}' : null);
+    final DriveEvent driveEvent = DriveEvent(
+      id: _nextId(),
+      kind: DriveEventKind.speedCamera,
+      timestamp: DateTime.now(),
+      latitude: event.latitude,
+      longitude: event.longitude,
+      title: cameraLabel,
+      subtitle: subtitle,
+      details: <String, dynamic>{
+        'flags': <String>[
+          if (event.fixed) 'Fixed',
+          if (event.mobile) 'Mobile',
+          if (event.traffic) 'Traffic',
+          if (event.distance) 'Average speed',
+          if (event.predictive) 'Predicted',
+        ],
+        if (event.maxspeed != null) 'limit': event.maxspeed,
+      },
+    );
+    _addEvent(driveEvent);
+    final DriveSessionSummary current = summary.value;
+    summary.value = current.copyWith(
+      speedCameraCount: current.speedCameraCount + 1,
+    );
+  }
+
+  void _onConstruction(GeoRect rect) {
+    final double latitude = (rect.minLat + rect.maxLat) / 2.0;
+    final double longitude = (rect.minLon + rect.maxLon) / 2.0;
+    final DriveEvent driveEvent = DriveEvent(
+      id: _nextId(),
+      kind: DriveEventKind.construction,
+      timestamp: DateTime.now(),
+      latitude: latitude,
+      longitude: longitude,
+      title: 'Road work detected',
+      subtitle: 'Zone ${(rect.maxLat - rect.minLat).abs().toStringAsFixed(3)}° × '
+          '${(rect.maxLon - rect.minLon).abs().toStringAsFixed(3)}°',
+      details: <String, dynamic>{
+        'bounds': rect,
+      },
+    );
+    _addEvent(driveEvent);
+    final DriveSessionSummary current = summary.value;
+    summary.value = current.copyWith(
+      constructionCount: current.constructionCount + 1,
+    );
+  }
+
+  void _onOverspeed() {
+    final int? diff = overspeedChecker.difference.value;
+    if (diff != null && diff > 0) {
+      final List<double> coords = gpsProducer.get_lon_lat();
+      final double longitude = coords[0];
+      final double latitude = coords[1];
+      if (_activeOverspeed == null) {
+        final DriveEvent newEvent = DriveEvent(
+          id: _nextId(),
+          kind: DriveEventKind.overspeed,
+          timestamp: DateTime.now(),
+          latitude: latitude,
+          longitude: longitude,
+          title: '+$diff km/h over limit',
+          subtitle: 'Ease off to return within the limit',
+          details: <String, dynamic>{'peak': diff},
+          isOngoing: true,
+          maxOverspeed: diff,
+        );
+        _activeOverspeed = newEvent;
+        _addEvent(newEvent);
+        _activeOverspeedDuration = Duration.zero;
+        final DriveSessionSummary current = summary.value;
+        summary.value = current.copyWith(
+          overspeedCount: current.overspeedCount + 1,
+          maxOverspeed: math.max(current.maxOverspeed, diff),
+          overspeedDuration:
+              _completedOverspeedDuration + _activeOverspeedDuration,
+        );
+        _startTicker();
+      } else {
+        final DriveEvent updated = _activeOverspeed!.copyWith(
+          latitude: latitude,
+          longitude: longitude,
+          title: '+$diff km/h over limit',
+          details: <String, dynamic>{
+            ..._activeOverspeed!.details,
+            'peak': math.max(_activeOverspeed!.maxOverspeed ?? diff, diff),
+          },
+          maxOverspeed: math.max(_activeOverspeed!.maxOverspeed ?? diff, diff),
+        );
+        _activeOverspeed = updated;
+        _replaceEvent(updated);
+        final DriveSessionSummary current = summary.value;
+        summary.value = current.copyWith(
+          maxOverspeed: math.max(current.maxOverspeed, diff),
+        );
+      }
+      _refreshActiveOverspeed();
+    } else {
+      _finaliseActiveOverspeed();
+    }
+  }
+
+  void _refreshActiveOverspeed() {
+    if (_activeOverspeed == null) return;
+    final DateTime now = DateTime.now();
+    _activeOverspeedDuration = now.difference(_activeOverspeed!.timestamp);
+    final DriveEvent updated =
+        _activeOverspeed!.copyWith(endTimestamp: now, isOngoing: true);
+    _activeOverspeed = updated;
+    _replaceEvent(updated);
+    summary.value = summary.value.copyWith(
+      overspeedDuration: _completedOverspeedDuration + _activeOverspeedDuration,
+    );
+  }
+
+  void _finaliseActiveOverspeed() {
+    if (_activeOverspeed == null) return;
+    _cancelTicker();
+    final DateTime now = DateTime.now();
+    final DriveEvent completed =
+        _activeOverspeed!.copyWith(endTimestamp: now, isOngoing: false);
+    _activeOverspeed = completed;
+    _replaceEvent(completed);
+    final Duration duration =
+        completed.duration ?? _activeOverspeedDuration;
+    _completedOverspeedDuration += duration;
+    _activeOverspeedDuration = Duration.zero;
+    summary.value = summary.value.copyWith(
+      overspeedDuration: _completedOverspeedDuration,
+      maxOverspeed:
+          math.max(summary.value.maxOverspeed, completed.maxOverspeed ?? 0),
+    );
+    _activeOverspeed = null;
+  }
+
+  void _addEvent(DriveEvent event) {
+    final List<DriveEvent> updated = List<DriveEvent>.from(events.value)
+      ..add(event);
+    events.value = updated;
+  }
+
+  void _replaceEvent(DriveEvent event) {
+    final List<DriveEvent> updated = List<DriveEvent>.from(events.value);
+    final int index = updated.indexWhere((DriveEvent e) => e.id == event.id);
+    if (index >= 0) {
+      updated[index] = event;
+      events.value = updated;
+    }
+  }
+
+  int _nextId() => ++_eventId;
+
+  void _startTicker() {
+    _overspeedTicker ??=
+        Timer.periodic(const Duration(seconds: 1), (_) => _refreshActiveOverspeed());
+  }
+
+  void _cancelTicker() {
+    _overspeedTicker?.cancel();
+    _overspeedTicker = null;
+  }
+
+  /// Dispose subscriptions and listeners.
+  Future<void> dispose() async {
+    _cancelTicker();
+    overspeedChecker.difference.removeListener(_onOverspeed);
+    for (final StreamSubscription<dynamic> sub in _subscriptions) {
+      await sub.cancel();
+    }
+    _subscriptions.clear();
+  }
+}

--- a/lib/ui/dashboard.dart
+++ b/lib/ui/dashboard.dart
@@ -22,14 +22,12 @@ class DashboardPage extends StatefulWidget {
   final AppController? controller;
   final RectangleCalculatorThread? calculator;
   final OverspeedChecker checker;
-  final ValueNotifier<String>? arStatus;
   final ValueNotifier<String>? direction;
   final ValueNotifier<String>? averageBearing;
   DashboardPage(
       {super.key,
       this.controller,
       this.calculator,
-      this.arStatus,
       this.direction,
       this.averageBearing,
       required this.checker});
@@ -59,8 +57,6 @@ class _DashboardPageState extends State<DashboardPage> {
   RectangleCalculatorThread? _calculator;
   late OverspeedChecker _checker;
   AppController? _controller;
-  String _arStatus = '';
-  ValueNotifier<String>? _arNotifier;
   double _acceleration = 0.0;
   String _direction = '-';
   String _averageBearing = '---.-°';
@@ -144,12 +140,6 @@ class _DashboardPageState extends State<DashboardPage> {
       _calculator!.gpsStatusNotifier.addListener(_updateFromCalculator);
       _calculator!.onlineStatusNotifier.addListener(_updateFromCalculator);
       _cameraSub = _calculator!.cameras.listen(_onCamera);
-    }
-
-    _arNotifier = widget.arStatus;
-    if (_arNotifier != null) {
-      _arStatus = _arNotifier!.value;
-      _arNotifier!.addListener(_updateArStatus);
     }
 
     _directionNotifier = widget.direction;
@@ -283,12 +273,6 @@ class _DashboardPageState extends State<DashboardPage> {
     });
   }
 
-  void _updateArStatus() {
-    setState(() {
-      _arStatus = _arNotifier!.value;
-    });
-  }
-
   Future<void> _addCamera() async {
     if (_calculator == null) return;
     final pos = _calculator!.positionNotifier.value;
@@ -399,7 +383,6 @@ class _DashboardPageState extends State<DashboardPage> {
       _calculator!.onlineStatusNotifier.removeListener(_updateFromCalculator);
       _cameraSub?.cancel();
     }
-    _arNotifier?.removeListener(_updateArStatus);
     _directionNotifier?.removeListener(_updateDirectionBearing);
     _averageBearingNotifier?.removeListener(_updateDirectionBearing);
     super.dispose();
@@ -597,24 +580,12 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   Widget _buildStatusRow() {
-    final children = <Widget>[
-      Expanded(child: _buildGpsWidget()),
-      const SizedBox(width: 16),
-      Expanded(child: _buildInternetWidget()),
-    ];
-    if (_arStatus.isNotEmpty) {
-      children.add(const SizedBox(width: 16));
-      children.add(Expanded(child: _buildAiWidget()));
-    }
-    return Row(children: children);
-  }
-
-  Widget _buildAiWidget() {
-    final Color color = _arStatus == 'HUMAN' ? Colors.red : Colors.blueGrey;
-    return _statusTile(
-      icon: Icons.smart_toy,
-      text: 'AI: $_arStatus',
-      color: color,
+    return Row(
+      children: [
+        Expanded(child: _buildGpsWidget()),
+        const SizedBox(width: 16),
+        Expanded(child: _buildInternetWidget()),
+      ],
     );
   }
 

--- a/lib/ui/drive_insights_page.dart
+++ b/lib/ui/drive_insights_page.dart
@@ -1,0 +1,580 @@
+import 'package:flutter/material.dart';
+
+import '../app_controller.dart';
+import '../drive_history_recorder.dart';
+
+/// Renders a polished dashboard highlighting interesting events captured during
+/// the current driving session.
+class DriveInsightsPage extends StatefulWidget {
+  const DriveInsightsPage({super.key, required this.controller});
+
+  final AppController controller;
+
+  @override
+  State<DriveInsightsPage> createState() => _DriveInsightsPageState();
+}
+
+class _DriveInsightsPageState extends State<DriveInsightsPage> {
+  late final DriveHistoryRecorder _recorder =
+      widget.controller.driveHistoryRecorder;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          colors: <Color>[
+            Color(0xFF0F2027),
+            Color(0xFF203A43),
+            Color(0xFF2C5364),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+      ),
+      child: SafeArea(
+        child: ValueListenableBuilder<DriveSessionSummary>(
+          valueListenable: _recorder.summary,
+          builder: (BuildContext context, DriveSessionSummary summary, _) {
+            return ValueListenableBuilder<List<DriveEvent>>(
+              valueListenable: _recorder.events,
+              builder: (BuildContext context, List<DriveEvent> events, __) {
+                return CustomScrollView(
+                  physics: const BouncingScrollPhysics(),
+                  slivers: <Widget>[
+                    SliverAppBar(
+                      backgroundColor: Colors.transparent,
+                      elevation: 0,
+                      pinned: true,
+                      title: const Text(
+                        'Drive insights',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.4,
+                        ),
+                      ),
+                      centerTitle: false,
+                    ),
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 20,
+                          vertical: 12,
+                        ),
+                        child: _SummaryHeader(
+                          summary: summary,
+                          eventCount: events.length,
+                        ),
+                      ),
+                    ),
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 20),
+                        child: _SummaryGrid(summary: summary),
+                      ),
+                    ),
+                    SliverPadding(
+                      padding: const EdgeInsets.fromLTRB(20, 24, 20, 32),
+                      sliver: events.isEmpty
+                          ? SliverToBoxAdapter(
+                              child: _EmptyState(theme: theme),
+                            )
+                          : SliverList.separated(
+                              itemCount: events.length,
+                              separatorBuilder: (_, __) => const SizedBox(height: 14),
+                              itemBuilder: (BuildContext context, int index) {
+                                final DriveEvent event = events[events.length - 1 - index];
+                                return _TimelineTile(event: event, theme: theme);
+                              },
+                            ),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryHeader extends StatelessWidget {
+  const _SummaryHeader({
+    required this.summary,
+    required this.eventCount,
+  });
+
+  final DriveSessionSummary summary;
+  final int eventCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final Duration duration = summary.overspeedDuration;
+    final String durationLabel = duration.inSeconds == 0
+        ? 'No overspeed recorded'
+        : 'Overspeed for ${_formatDuration(duration)}';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          'Professional drive log',
+          style: textTheme.headlineSmall?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          eventCount == 0
+              ? 'Your next trip will appear here with beautiful metrics.'
+              : 'Tracking $eventCount insight${eventCount == 1 ? '' : 's'} this session.',
+          style: textTheme.bodyMedium?.copyWith(
+            color: Colors.white70,
+            height: 1.35,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.08),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white12),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+          child: Row(
+            children: <Widget>[
+              _SummaryBadge(
+                icon: Icons.speed,
+                color: const Color(0xFF56CCF2),
+                background: const Color(0x331C92F2),
+                label: '${summary.speedCameraCount} cameras',
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(
+                  durationLabel,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.2,
+                  ),
+                ),
+              ),
+              if (summary.maxOverspeed > 0)
+                _SummaryBadge(
+                  icon: Icons.warning_amber_rounded,
+                  color: const Color(0xFFFFA726),
+                  background: const Color(0x33FF9800),
+                  label: 'Peak +${summary.maxOverspeed} km/h',
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryGrid extends StatelessWidget {
+  const _SummaryGrid({required this.summary});
+
+  final DriveSessionSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<_MetricCardData> cards = <_MetricCardData>[
+      _MetricCardData(
+        icon: Icons.my_location,
+        label: 'Cameras passed',
+        value: summary.speedCameraCount.toString(),
+        gradient: const [Color(0xFF56CCF2), Color(0xFF2F80ED)],
+      ),
+      _MetricCardData(
+        icon: Icons.engineering,
+        label: 'Work zones',
+        value: summary.constructionCount.toString(),
+        gradient: const [Color(0xFFF7971E), Color(0xFFFF512F)],
+      ),
+      _MetricCardData(
+        icon: Icons.shield_moon,
+        label: 'Overspeed events',
+        value: summary.overspeedCount.toString(),
+        gradient: const [Color(0xFF00C9FF), Color(0xFF92FE9D)],
+      ),
+      _MetricCardData(
+        icon: Icons.timer,
+        label: 'Overspeed time',
+        value: _formatDuration(summary.overspeedDuration),
+        gradient: const [Color(0xFF8E2DE2), Color(0xFF4A00E0)],
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double maxWidth = constraints.maxWidth;
+        final bool isWide = maxWidth > 620;
+        return Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: cards
+              .map((card) => SizedBox(
+                    width: isWide
+                        ? (maxWidth - 16) / 2
+                        : maxWidth,
+                    child: _MetricCard(data: card),
+                  ))
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _MetricCardData {
+  const _MetricCardData({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.gradient,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final List<Color> gradient;
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({required this.data});
+
+  final _MetricCardData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: data.gradient,
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: data.gradient.last.withOpacity(0.35),
+            blurRadius: 18,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 22),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Container(
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.18),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            padding: const EdgeInsets.all(10),
+            child: Icon(data.icon, color: Colors.white, size: 26),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  data.value,
+                  style: textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  data.label,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: Colors.white.withOpacity(0.9),
+                    letterSpacing: 0.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: Colors.white.withOpacity(0.05),
+        border: Border.all(color: Colors.white10),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 40),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(Icons.auto_awesome, color: Colors.white.withOpacity(0.6), size: 42),
+          const SizedBox(height: 18),
+          Text(
+            'No events yet',
+            style: theme.textTheme.titleLarge?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Start a drive to see cameras, construction alerts and overspeed '
+            'analytics presented in real time.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: Colors.white70,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SummaryBadge extends StatelessWidget {
+  const _SummaryBadge({
+    required this.icon,
+    required this.color,
+    required this.background,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color color;
+  final Color background;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(icon, color: color, size: 20),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TimelineTile extends StatelessWidget {
+  const _TimelineTile({required this.event, required this.theme});
+
+  final DriveEvent event;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color accent = _accentColorForEvent(event.kind);
+    final String timeLabel =
+        TimeOfDay.fromDateTime(event.timestamp).format(context);
+    final String subtitle = event.subtitle ??
+        'Lat ${event.latitude.toStringAsFixed(4)}, '
+            'Lon ${event.longitude.toStringAsFixed(4)}';
+    final List<Widget> chips = <Widget>[];
+    if (event.kind == DriveEventKind.overspeed && event.maxOverspeed != null) {
+      chips.add(_EventChip(
+        label: '+${event.maxOverspeed} km/h',
+        color: accent,
+      ));
+    }
+    final Duration? duration = event.duration;
+    if (duration != null && duration.inSeconds > 0) {
+      chips.add(_EventChip(
+        label: _formatDuration(duration),
+        color: Colors.white.withOpacity(0.14),
+        textColor: Colors.white70,
+      ));
+    }
+    if (event.details['flags'] is List &&
+        (event.details['flags'] as List).isNotEmpty) {
+      for (final dynamic flag in event.details['flags'] as List) {
+        chips.add(_EventChip(
+          label: flag.toString(),
+          color: Colors.white.withOpacity(0.12),
+          textColor: Colors.white70,
+        ));
+      }
+    }
+    if (event.isOngoing) {
+      chips.add(_EventChip(
+        label: 'LIVE',
+        color: accent,
+        textColor: Colors.black,
+      ));
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(22),
+        color: Colors.white.withOpacity(0.06),
+        border: Border.all(color: Colors.white10),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Container(
+                width: 46,
+                height: 46,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: LinearGradient(
+                    colors: <Color>[
+                      accent,
+                      accent.withOpacity(0.65),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+                child: Icon(
+                  _iconForEvent(event.kind),
+                  color: Colors.white,
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      event.title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '$subtitle · $timeLabel',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: Colors.white70,
+                        height: 1.35,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (chips.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 6,
+              children: chips,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _EventChip extends StatelessWidget {
+  const _EventChip({
+    required this.label,
+    required this.color,
+    this.textColor,
+  });
+
+  final String label;
+  final Color color;
+  final Color? textColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: textColor ?? Colors.white,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.3,
+            ),
+      ),
+    );
+  }
+}
+
+Color _accentColorForEvent(DriveEventKind kind) {
+  switch (kind) {
+    case DriveEventKind.speedCamera:
+      return const Color(0xFF56CCF2);
+    case DriveEventKind.construction:
+      return const Color(0xFFFFA726);
+    case DriveEventKind.overspeed:
+      return const Color(0xFFEF5350);
+  }
+}
+
+IconData _iconForEvent(DriveEventKind kind) {
+  switch (kind) {
+    case DriveEventKind.speedCamera:
+      return Icons.speed;
+    case DriveEventKind.construction:
+      return Icons.engineering;
+    case DriveEventKind.overspeed:
+      return Icons.warning_amber_rounded;
+  }
+}
+
+String _formatDuration(Duration duration) {
+  if (duration.inSeconds <= 0) return '0s';
+  final int hours = duration.inHours;
+  final int minutes = duration.inMinutes.remainder(60);
+  final int seconds = duration.inSeconds.remainder(60);
+  final List<String> parts = <String>[];
+  if (hours > 0) parts.add('${hours}h');
+  if (minutes > 0) parts.add('${minutes}m');
+  if (seconds > 0 && hours == 0) parts.add('${seconds}s');
+  return parts.join(' ');
+}

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../app_controller.dart';
 import 'actions_page.dart';
-import 'ar_page.dart';
 import 'dashboard.dart';
+import 'drive_insights_page.dart';
 import 'info_page.dart';
 import 'map_page.dart';
 import 'stats_page.dart';
@@ -36,7 +36,6 @@ class _HomePageState extends State<HomePage> {
       DashboardPage(
         controller: widget.controller,
         calculator: widget.controller.calculator,
-        arStatus: widget.controller.arStatusNotifier,
         direction: widget.controller.directionNotifier,
         averageBearing: widget.controller.averageBearingValue,
         checker: widget.controller.overspeedChecker,
@@ -46,10 +45,7 @@ class _HomePageState extends State<HomePage> {
         poiStream: widget.controller.poiStream,
         onPoiLookup: widget.controller.lookupPois,
       ),
-      ArPage(
-        controller: widget.controller,
-        onReturn: _showMain,
-      ),
+      DriveInsightsPage(controller: widget.controller),
       InfoPage(calculator: widget.controller.calculator),
       StatsPage(calculator: widget.controller.calculator),
     ];
@@ -77,7 +73,8 @@ class _HomePageState extends State<HomePage> {
           BottomNavigationBarItem(
               icon: Icon(Icons.dashboard), label: 'Dashboard'),
           BottomNavigationBarItem(icon: Icon(Icons.map), label: 'Map'),
-          BottomNavigationBarItem(icon: Icon(Icons.camera_alt), label: 'AR'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.insights), label: 'Insights'),
           BottomNavigationBarItem(
               icon: Icon(Icons.info_outline), label: 'Info'),
           BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Stats'),


### PR DESCRIPTION
## Summary
- add a DriveHistoryRecorder that captures speed camera, construction and overspeed events and maintains per-session metrics for the UI
- introduce a DriveInsightsPage with a premium-styled layout to visualise live drive summaries and the recorded event timeline
- swap the AR tab in HomePage for the new insights tab and clean up dashboard status widgets now that AR state is gone

## Testing
- not run (environment lacks Flutter/Dart tooling)

------
https://chatgpt.com/codex/tasks/task_e_68e28bbd5e50832ca5d5133070012490